### PR TITLE
Add available hours to equipment

### DIFF
--- a/app/controllers/equipment_controller.rb
+++ b/app/controllers/equipment_controller.rb
@@ -116,11 +116,9 @@ class EquipmentController < ApplicationController
   end
 
   def save_availability
-    if params.require(:equipment)[:available_hours]
-      params.require(:equipment)[:available_hours].each do |schedule|
-        availabilities = @equipment.available_hours.new(schedule_params(schedule))
-        availabilities.save
-      end
+    params.require(:equipment)[:available_hours]&.each do |schedule|
+      availabilities = @equipment.available_hours.new(schedule_params(schedule))
+      availabilities.save
     end
   end
 

--- a/app/models/available_hour.rb
+++ b/app/models/available_hour.rb
@@ -2,4 +2,12 @@ class AvailableHour < ApplicationRecord
   enum day_of_week: [:sunday, :monday, :tuesday, :wednesday, :thursday, :friday, :saturday]
 
   belongs_to :equipment
+  validates :start_time, :end_time, :day_of_week, presence: true
+  validate :date_range_valid
+
+  def date_range_valid
+    return if start_time.blank?
+
+    errors.add(:end_time, "can't be before start time") if end_time.present? && end_time < start_time
+  end
 end

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -5,7 +5,7 @@ class Equipment < ApplicationRecord
   has_many :materials, through: :equipment_materials
   has_many :equipment_capabilities, dependent: :destroy
   has_many :capabilities, through: :equipment_capabilities
-  has_many :available_hours
+  has_many :available_hours, dependent: :destroy
   has_many :reservations
   belongs_to :lab_space
 


### PR DESCRIPTION
**User Story:** #16 

- Agregas el horario disponible al momento de crear/updatear un equipo

**Request received by controller:**
```{
    "equipment":{
        "name": "nombre del equipo",
        "description": "gonna miss the rain",
        "materials": "madera, tela",
        "capabilities": "cort, imprime",
        "available_hours": [
            {
                "start_time": "7:00",
                "end_time": "14:00",
                "day_of_week": 1
            },
            {
                "start_time": "1:00",
                "end_time": "3:00",
                "day_of_week": 2
            }
        ]
    }
}
```

Notes:
-  Active Record assigns a default date to `start_time` & `end_time`
ex: `start_time: "2000-01-01 07:00:00"` `end_time: "2000-01-01 14:00:00"`
to format the time to Hour:Minutes as we want we can use `.to_formatted_s(:time)`
ex: `start_time.to_formatted_s(:time)` will return `"07:00"`