### PR TITLE
Add capabilities and materials to equipment views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea
 public/uploads/*
+.bash_history
+
 
 # Created by https://www.gitignore.io/api/ruby,rails,macos,windows
 # Edit at https://www.gitignore.io/?templates=ruby,rails,macos,windows

--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -187,7 +187,7 @@ h1 {
 
 /* Pills
 ----------------------------- */
-.tagslist.inline .pill {
+.taglist.inline .pill {
   margin-bottom: 10px;
 }
 .Resultados .sidebar .selectize-input.items .item,

--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -187,6 +187,9 @@ h1 {
 
 /* Pills
 ----------------------------- */
+.tagslist.inline .pill {
+  margin-bottom: 10px;
+}
 .Resultados .sidebar .selectize-input.items .item,
 .pill {
   border-radius: 40px;

--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -236,12 +236,6 @@ h1 {
   background-color: transparent;
   font-size: 10px;
   padding: 3px 8px;
-  &::after {
-    content: '×';
-    color: #a4a5c1;
-    font-weight: 800;
-    margin-left: 5px;
-  }
 }
 
 /* Buttons

--- a/app/assets/stylesheets/_equipment.scss
+++ b/app/assets/stylesheets/_equipment.scss
@@ -39,7 +39,7 @@ hr {
 .resultsContainer {
   .SearchResult {
     border-bottom: 1px solid #ccc;
-    padding-bottom: 40px;
+    padding-bottom: 20px;
     margin-bottom: 40px;
     .taglist li {
       margin: 0 5px;
@@ -65,6 +65,12 @@ hr {
       tr td:last-child {
         padding-left: 25px;
       }
+    }
+    .taglist {
+      width: 70%;
+    }
+    .pill {
+      margin-bottom: 10px;
     }
   }
 }

--- a/app/assets/stylesheets/_equipment.scss
+++ b/app/assets/stylesheets/_equipment.scss
@@ -41,6 +41,11 @@ hr {
     border-bottom: 1px solid #ccc;
     padding-bottom: 20px;
     margin-bottom: 40px;
+    .reserveBtn {
+      opacity: 0;
+      padding: 8px 15px;
+    }
+    &:hover .reserveBtn {opacity: 1;}
     .taglist li {
       margin: 0 5px;
       &:first-child {

--- a/app/assets/stylesheets/_equipment.scss
+++ b/app/assets/stylesheets/_equipment.scss
@@ -69,9 +69,6 @@ hr {
     .taglist {
       width: 70%;
     }
-    .pill {
-      margin-bottom: 10px;
-    }
   }
 }
 .EquipoForm {

--- a/app/assets/stylesheets/_equipment.scss
+++ b/app/assets/stylesheets/_equipment.scss
@@ -202,4 +202,27 @@ hr {
     }
   }
 }
-
+.EquipmentDetail {
+  .detailsTable {
+    margin-bottom: 20px;
+    width: 100%;
+    tr td:first-child {
+      width: 30%;
+      font-weight: 600;
+    }
+  }
+  .entitytag {
+    position: relative;
+    top: -4px;
+  }
+  .ico.ico-cal {
+    width: 26px;
+    position: relative;
+    top: -4px;
+    margin-left: 5px;
+  }
+  #calendar h2 {
+    color: $gray1;
+    font-size: 1.35em;
+  }
+}

--- a/app/assets/stylesheets/_home.scss
+++ b/app/assets/stylesheets/_home.scss
@@ -54,7 +54,24 @@
       display: inline-block;
     }
   }
+  .tagBox {
+    text-align: left;
+    .pill {
+      margin: 0 4px 4px;
+
+    }
+  }
   .homeFooter p {
     font-size: 1.17rem;
+  }
+  .searchBtn {
+    transition: box-shadow 300ms;
+    &:focus,
+    &:hover {
+      box-shadow: 0 0 30px rgba($highlight, .4);
+    }
+  }
+  .search-form {
+    display: none;
   }
 }

--- a/app/assets/stylesheets/_labs.scss
+++ b/app/assets/stylesheets/_labs.scss
@@ -23,13 +23,10 @@
     }
     .taglist {
       position: relative;
-      top: 6px;
-      margin-left: 20px;
+      // top: 6px;
+      margin-left: 15px;
       .pill {
         cursor: default;
-      }
-      li {
-        display: inline-block;
       }
     }
   }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,3 +18,4 @@ class ApplicationController < ActionController::Base
     end
   end
 end
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,4 +18,3 @@ class ApplicationController < ActionController::Base
     end
   end
 end
-

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,6 +3,8 @@ class HomeController < ApplicationController
   config.cache_store = :null_store
   def landing
     @body_class = 'Home'
+    @capabilities = Capability.all
+    @materials = Material.all
     render layout: false
   end
 end

--- a/app/views/equipment/index.html.erb
+++ b/app/views/equipment/index.html.erb
@@ -13,14 +13,6 @@
           <p class="title">Material</p>
           <select multiple name="materiales" id="select-material">
             <option value="">Materiales</option>
-            <option value="1">Material 1</option>
-            <option value="1">Material 1</option>
-            <option value="2">Material 2</option>
-            <option value="3">Material 3</option>
-            <option value="4">Material 4</option>
-            <option value="5">Material 5</option>
-            <option value="6">Material 6</option>
-            <option value="7">Material 7</option>
             <% @materials.each do |m|  %>
               <option value="<%= m.id %>"><%= m.name %></option>
             <% end %>
@@ -37,15 +29,6 @@
           <p class="title">Capacidad</p>
           <select multiple name="capacidades" id="select-capacidad">
             <option value="">Capacidades</option>
-            <option value="1">Capacidad 1</option>
-            <option value="2">Capacidad 2</option>
-            <option value="3">Capacidad 3</option>
-            <option value="4">Capacidad 4</option>
-            <option value="5">Capacidad 5</option>
-            <option value="6">Capacidad 6</option>
-            <option value="7">Capacidad 7</option>
-            <option value="8">Capacidad 8</option>
-            <option value="9">Capacidad 9</option>
             <% @capabilities.each do |c|  %>
               <option value="<%= c.id %>"><%= c.name %></option>
             <% end %>
@@ -95,9 +78,12 @@
               </table>
               <p class="desc"><%= equipment.description %></p>
               <ul class="inline taglist">
-                <li><div class="pill gray small">aluminio</div></li>
-                <li><div class="pill gray small">pl&aacute;stico</div></li>
-                <li><div class="pill gray small">madera</div></li>
+                <% equipment.capabilities.each do | c | %>
+                  <li><div class="pill gray small"><%= c.name %></div></li>
+                <% end %>
+                <% equipment.materials.each do | m | %>
+                  <li><div class="pill gray small"><%= m.name %></div></li>
+                <% end %>
               </ul>
             </article>
           <% end %>

--- a/app/views/equipment/index.html.erb
+++ b/app/views/equipment/index.html.erb
@@ -126,8 +126,8 @@
 
   </script>
   <%# javascript_include_tag "selectize.min" %>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.6/css/selectize.css">
   <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.6/css/selectize.default.min.css"> -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.6/css/selectize.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.6/js/standalone/selectize.min.js"></script>
   <script>
     const opts = {

--- a/app/views/equipment/index.html.erb
+++ b/app/views/equipment/index.html.erb
@@ -17,13 +17,6 @@
               <option value="<%= m.id %>"><%= m.name %></option>
             <% end %>
           </select>
-          <div class="filterContainer">
-            <ul class="inline filterlist hidden">
-              <li><div class="pill border xsmall with-cross">aluminio</div></li>
-              <li><div class="pill border xsmall with-cross">pl&aacute;stico</div></li>
-              <li><div class="pill border xsmall with-cross">madera</div></li>
-            </ul>
-          </div>
         </section>
         <section class="filter">
           <p class="title">Capacidad</p>
@@ -33,13 +26,6 @@
               <option value="<%= c.id %>"><%= c.name %></option>
             <% end %>
           </select>
-          <div class="filterContainer">
-            <ul class="inline filterlist hidden">
-              <li><div class="pill border xsmall with-cross">aluminio</div></li>
-              <li><div class="pill border xsmall with-cross">pl&aacute;stico</div></li>
-              <li><div class="pill border xsmall with-cross">madera</div></li>
-            </ul>
-          </div>
         </section>
       </div>
     </div>
@@ -54,7 +40,7 @@
             <article class="SearchResult">
               <h2 class="title mb-3">
                 <%= link_to equipment.name, [equipment.lab_space.lab, equipment.lab_space, equipment] %>
-                <a href="#" class="ml-5 btn highlight small lp" style="padding: 8px 15px">Reservar</a>
+                <%= link_to "Reservar", [equipment.lab_space.lab, equipment.lab_space, equipment], class: "ml-5 reserveBtn btn highlight small lp"%>
               </h2>
               <table class="detailsTable">
                 <tbody>
@@ -94,20 +80,65 @@
   <%# render partial: 'shared/search' %>
 </div>
 <% content_for :scripts do %>
+  <script>
+    const $resultDivs = $('article.SearchResult');
+    let data = <%= raw(@equipment.as_json(only: [:capabilities, :materials], include:[{capabilities: {only: :id}}, {materials: {only: :id}}]).to_json) %>;
+    // Prepare data for easier manipulation (remove object info)
+    data = data.map((eq, i) => {
+      eq.forindex = i;
+      eq.capabilities = eq.capabilities.map(c => c.id);
+      eq.materials = eq.materials.map(m => m.id);
+      return eq;
+    });
+
+    function filterOnCollection(collectionName) {
+      return function(collection, selected) { // selected is Array
+        return collection.filter(function(item) {
+          return selected.every(function(cv) {
+            // Check if every selected item is in this results' `collectionName`
+            return item[collectionName].indexOf(parseInt(cv, 10)) > -1;
+          });
+        });
+      };
+    }
+
+    const filterMaterials = filterOnCollection('materials');
+    const filterCapabilities = filterOnCollection('capabilities');
+
+    function filterResults() {
+      let materialsQuery = sel1.getValue();
+      let capQuery = sel2.getValue();
+      const results = filterCapabilities(filterMaterials(data, materialsQuery), capQuery).map(r => r.forindex);;
+      $resultDivs.hide();
+      results.forEach(function(index) {
+        $resultDivs.eq(index).show();
+      });
+    }
+
+    $("#showtags").on('change', function() {
+      if($(this).prop('checked') === true) {
+        $('.taglist').show();
+      }
+      else {
+        $('.taglist').hide();
+      }
+    });
+
+  </script>
   <%# javascript_include_tag "selectize.min" %>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.6/css/selectize.css">
   <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.6/css/selectize.default.min.css"> -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.6/js/standalone/selectize.min.js"></script>
   <script>
-    $('#select-material').selectize({
+    const opts = {
       sortField: 'text',
       plugins: ['remove_button']
-    });
-    $('#select-capacidad').selectize({
-      sortField: 'text'
-    });
+    };
+    let $sel1 = $('#select-material').selectize(opts);
+    let $sel2 = $('#select-capacidad').selectize(opts);
+    let sel1 = $sel1[0].selectize;
+    let sel2 = $sel2[0].selectize;
+    sel1.on('change', filterResults);
+    sel2.on('change', filterResults);
   </script>
-<% end %>
-<% if @lab_space %>
-  <%= link_to 'New Equipment', new_lab_lab_space_equipment_path %>
 <% end %>

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -22,6 +22,14 @@
           <div class="section-body">
             <div class="row">
               <div class="col">
+                <table class="detailsTable">
+                  <tbody>
+                    <tr>
+                      <td>Laboratorio:</td>
+                      <td><%= link_to @equipment.lab_space.name, lab_lab_space_path(@equipment.lab_space.id) %></td>
+                    </tr>
+                  </tbody>
+                </table>
                 <p><%= @equipment.description %></p>
               </div>
             </div>
@@ -56,7 +64,7 @@
     </div>
   </section>
   <section class="Horario">
-    <h2 class="mb-3">Horario</h2>
+    <h2 class="mb-3">Horario <%= image_tag "icons/calendar.svg", class: 'ico ico-cal' %></h2>
     <div id="calendar"></div>
   </section>
 </div>

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -25,6 +25,18 @@
                 <p><%= @equipment.description %></p>
               </div>
             </div>
+            <div class="row">
+              <div class="col">
+                <ul class="tagslist inline">
+                  <% @equipment.capabilities.each do |c| %>
+                    <li><div class="pill gray small"><%= c.name %></div></li>
+                  <% end %>
+                  <% @equipment.materials.each do | m | %>
+                    <li><div class="pill gray small"><%= m.name %></div></li>
+                  <% end %>
+                </ul>
+              </div>
+            </div>
           </div>
         </section>
       </div>

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -35,7 +35,7 @@
             </div>
             <div class="row">
               <div class="col">
-                <ul class="tagslist inline">
+                <ul class="taglist inline">
                   <% @equipment.capabilities.each do |c| %>
                     <li><div class="pill gray small"><%= c.name %></div></li>
                   <% end %>
@@ -64,7 +64,8 @@
     </div>
   </section>
   <section class="Horario">
-    <h2 class="mb-3">Horario <%= image_tag "icons/calendar.svg", class: 'ico ico-cal' %></h2>
+    <h2>Horario <%= image_tag "icons/calendar.svg", class: 'ico ico-cal' %></h2>
+    <p class="mb-5 mt-1">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ex odio, ut corporis error, necessitatibus omnis laudantium hic provident a maxime.</p>
     <div id="calendar"></div>
   </section>
 </div>

--- a/app/views/home/landing.html.erb
+++ b/app/views/home/landing.html.erb
@@ -1,69 +1,166 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<title>Makers</title>
-		<%= csrf_meta_tags %>
-		<%= csp_meta_tag %>
+  <head>
+    <title>Makers</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
 
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap-reboot.min.css">
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap-grid.min.css">
-		<%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-		<%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
-	</head>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap-reboot.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap-grid.min.css">
+    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+  </head>
 
-	<body class="<%= @body_class %>">
-		<div class="container tac">
+  <body class="<%= @body_class %>">
+    <div class="container tac">
       <div class="standard header home">
         <div class="row">
           <%= render partial: 'shared/nav' %>
         </div>
       </div>
-			<a href="#" class="logo">
-				<%= image_tag "logo.svg", alt: "Makers Program" %>
-				<p class="tecbrand">@Tec de Monterrey</p>
-			</a>
-			<h2 class="tagline">&iquest;Qu&eacute; quieres crear hoy?</h2>
-			<div class="QueryBuilder">
-				<div class="row no-gutters">
-					<div class="col">
-						<p class="stmt">Quiero</p>
-					</div>
-					<div class="col">
-						<input type="text" name="capacidades" placeholder="capacidades" id="query-capacidades" class="fuzzy-input">
-					</div>
-					<div class="col">
-						<p class="stmt">usando</p>
-					</div>
-					<div class="col">
-						<input type="text" name="materiales" placeholder="materiales" id="query-materiales" class="fuzzy-input">
-					</div>
-					<div class="col">
-						<a href="#" class="highlight large btn" role="button">Buscar</a>
-					</div>
-				</div>
-			</div>
-			<section class="queryOptionsContainer">
-				<div class="pill white">acero</div>
-				<div class="pill white">madera</div>
-				<div class="pill white">pl&aacute;stico</div>
-				<div class="pill white">acero</div>
-				<div class="pill white">madera</div>
-				<div class="pill white">pl&aacute;stico</div>
-				<div class="pill white">acero</div>
-				<div class="pill white">madera</div>
-				<div class="pill white">pl&aacute;stico</div>
-			</section>
-			<footer class="homeFooter">
-				<p>
-					o consulta el <%= link_to equipment_index_path do %>
-						<%= content_tag :strong, "cat&aacute;logo de equipos".html_safe, :class => "bold" %>
-					<% end %>
-				</p>
-			</footer>
-			<% #render partial: 'shared/search' %>
-		</div>
+      <a href="#" class="logo">
+        <%= image_tag "logo.svg", alt: "Makers Program" %>
+        <p class="tecbrand">@Tec de Monterrey</p>
+      </a>
+      <h2 class="tagline">&iquest;Qu&eacute; quieres crear hoy?</h2>
+      <div class="QueryBuilder">
+        <div class="row no-gutters">
+          <div class="col">
+            <p class="stmt">Quiero</p>
+          </div>
+          <div class="col">
+            <div class="tagBox" id="capabilities"></div>
+            <input type="text" name="capacidades" placeholder="capacidades" id="query-capacidades" class="fuzzy-input">
+          </div>
+          <div class="col">
+            <p class="stmt">usando</p>
+          </div>
+          <div class="col">
+            <div class="tagBox" id="materials"></div>
+            <input type="text" name="materiales" placeholder="materiales" id="query-materiales" class="fuzzy-input">
+          </div>
+          <div class="col">
+            <a href="#" class="highlight large btn searchBtn" role="button">Buscar</a>
+          </div>
+        </div>
+      </div>
+      <section class="queryOptionsContainer" id="default">
+        <% @capabilities.to_a.sample(5).each do |c| %>
+          <div data-type="capabilities" class="pill white"><%= c.name %></div>
+        <% end %>
+        <% @materials.to_a.sample(5).each do |m| %>
+          <div data-type="materials" class="pill white"><%= m.name %></div>
+        <% end %>
+      </section>
+      <section class="queryOptionsContainer" id="results" style="display:none;"> </section>
+      <footer class="homeFooter">
+        <p>
+          o consulta el <%= link_to equipment_index_path do %>
+            <%= content_tag :strong, "cat&aacute;logo de equipos".html_safe, :class => "bold" %>
+          <% end %>
+        </p>
+      </footer>
+      <%= render partial: 'shared/search' %>
+    </div>
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <script>
+      const $pillBox = $('.queryOptionsContainer#results');
+      const $defaultPillBox = $('.queryOptionsContainer#default');
+
+      window.capabilities = <%= raw(@capabilities.as_json(only: [:id, :name]).to_json) %>;
+      window.materials = <%= raw(@materials.as_json(only: [:id, :name]).to_json) %>;
+
+      const $queryCap = $("#query-capacidades");
+      const $queryMat = $("#query-materiales");
+
+
+      function draw(results, type) {
+        const resultDivs = results.map(r => {
+          return `<div data-id="${r.id}" data-type="${type}" class="pill white">${r.name}</div>`;
+        });
+        $pillBox.html(resultDivs);
+        bindPills();
+      }
+      const processQueryOnCollection = function(collection) {
+        return function() {
+          const query = $(this).val().trim().toLowerCase();
+          if(query == "") {
+            console.log(query);
+            $pillBox.hide();
+            $defaultPillBox.show();
+            return false;
+          }
+
+          const results = window[collection].filter(c => c.name.toLowerCase().indexOf(query) > -1);
+          $defaultPillBox.hide();
+          $pillBox.show();
+          draw(results, collection);
+        };
+      };
+
+      const tagFocus = function(collection, handler) {
+        return function() {
+          if($(this).val().trim() !== "") {
+            return handler();
+          }
+          $defaultPillBox.hide();
+          draw(window[collection].slice(0,10), collection);
+          $pillBox.show();
+        };
+      };
+
+      const filterCapabilities = processQueryOnCollection('capabilities').bind($queryCap);
+      const filterMaterials = processQueryOnCollection('materials').bind($queryMat);
+
+      // Event handlers
+      $queryCap.on('input', filterCapabilities);
+      $queryMat.on('input', filterMaterials);
+
+      function bindPills() {
+        $('.queryOptionsContainer .pill.white').click(onOptionClick);
+      }
+      bindPills();
+
+      function onOptionClick() {
+        console.log('onpillclick');
+        let $pill = $(this).remove();
+        if($pill.data('type') == 'capabilities') {
+          $("#capabilities").append($pill);
+        }
+        else {
+          $("#materials").append($pill);
+        }
+        $pill.on('click', onSelectedOptionClick);
+      }
+      function onSelectedOptionClick() {
+        let $pill = $(this).remove();
+        $('.queryOptionsContainer').filter(':visible').append($pill);
+      }
+
+      function submitForm() {
+        const capabilities = $('.tagBox#capabilities .pill').toArray().map(p => p.textContent.trim()).join(',');
+        const materials = $('.tagBox#materials .pill').toArray().map(p => p.textContent.trim()).join(',');
+        $('#materials_query').val(materials);
+        $('#capabilities_query').val(capabilities);
+        $('.search-form').submit();
+      }
+      $('.searchBtn').click(function(e) {
+        e.preventDefault();
+        submitForm();
+      });
+
+
+      // On focus, show a sample of 10 tags
+      $queryCap.on('focus', tagFocus('capabilities', filterCapabilities));
+      $queryMat.on('focus', tagFocus('materials', filterMaterials));
+
+//      $([$queryCap[0], $queryMat[0]]).on('blur', function() {
+//        $pillBox.hide();
+//        $defaultPillBox.show();
+//      });
+
+    </script>
     <%= yield(:scripts) if content_for?(:scripts)  %> </body>
-	</body>
+  </body>
 </html>
 

--- a/app/views/labs/index.html.erb
+++ b/app/views/labs/index.html.erb
@@ -13,25 +13,35 @@
     <section class="labList">
       <% if !@labs.blank? %>
         <% @labs.each do |lab| %>
+          <%
+            tags = Array.new
+            lab.lab_spaces.each do | ls | ls.equipment.each do | e |
+              tags = tags + e.capabilities.map{|c| c.name}
+              tags = tags + e.materials.map{|m| m.name}
+            end; end;
+            tags.uniq!
+          %>
           <article class="labEntry">
             <div class="row">
               <div class="col-10">
                 <div class="container">
                   <div class="row pl-3">
                     <h2 class="title"><%= lab.name %></h2>
-                    <ul class="taglist">
-                      <li><div class="pill gray small">aluminio</div></li>
-                      <li><div class="pill gray small">pl&aacute;stico</div></li>
-                      <li><div class="pill gray small">madera</div></li>
-                    </ul>
                   </div>
                   <div class="row no-gutters semibold">
                     <div class="col-2 pl-1">
-                      <p class="location"><%= lab.location %></p>
+                      <p class="location mb-2"><%= lab.location %></p>
                     </div>
                     <div class="col-3">
-                      <p class="horarios"><%=  (defined? lab.horario) ? lab.horario : "HORARIO" %></p>
+                      <p class="horarios mb-2"><%=  (defined? lab.horario) ? lab.horario : "HORARIO" %></p>
                     </div>
+                  </div>
+                  <div class="row">
+                    <ul class="taglist inline">
+                      <% tags.each do |t| %>
+                        <li><div class="pill gray small"><%= t %></div></li>
+                      <% end %>
+                    </ul>
                   </div>
                 </div>
               </div>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -1,5 +1,5 @@
-<%= form_tag(equipment_index_path, method: :get) do %>
-  Equipment <%= text_field_tag :equipment_query, params[:equipment_query] %>
+<%= form_tag(equipment_index_path, method: :get, class: 'search-form') do %>
+  <%# Equipment <%= text_field_tag :equipment_query, params[:equipment_query] %>
   Materials <%= text_field_tag :materials_query, params[:materials_query] %>
   Capabilities <%= text_field_tag :capabilities_query, params[:capabilities_query] %>
   <%= submit_tag 'Search', name: nil %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,6 +46,15 @@ puts "Seeding the database..."
   end
 end
 
+## Seed capabilities
+12.times do
+  Capability.create!(name: Faker::Verb.base)
+end
+
+## Seed materials
+8.times do
+  Material.create!(name: Faker::Construction.unique.material)
+end
 
 ## Seed users
 puts "\tSeeding users..."

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,6 +10,16 @@ require 'faker'
 
 puts "Seeding the database..."
 
+## Seed capabilities
+12.times do
+  Capability.create!(name: Faker::Verb.base)
+end
+
+## Seed materials
+8.times do
+  Material.create!(name: Faker::Construction.unique.material)
+end
+
 2.times do
 
   lab = Lab.create!(
@@ -34,7 +44,9 @@ puts "Seeding the database..."
       name: Faker::App.name,
       description: Faker::Lorem.sentence(100, true, 10),
       remote_image_url: "http://lorempixel.com/600/440",
-      technical_description: Faker::Lorem.sentence(40, true, 15)
+      technical_description: Faker::Lorem.sentence(40, true, 15),
+      capability_ids: Capability.ids.sample(6),
+      material_ids: Material.ids.sample(4)
     )
     5.times do |i|
       eq.available_hours.create!(
@@ -46,15 +58,8 @@ puts "Seeding the database..."
   end
 end
 
-## Seed capabilities
-12.times do
-  Capability.create!(name: Faker::Verb.base)
-end
 
-## Seed materials
-8.times do
-  Material.create!(name: Faker::Construction.unique.material)
-end
+
 
 ## Seed users
 puts "\tSeeding users..."


### PR DESCRIPTION
This PR:

- Adds seeds for capabilities and materials and associates them to the generated seeded equipment
- Adds capabilities and materials to equipment **listing** (pills/tags)
- Adds capabilities and materials to equipment **show** (details view)
- Adds the corresponding lab space to the equipment details view
- Makes a few UI improvements to the equipment details view
- Adds dynamic filters for filtering on capability and materials on equipment listing / search results
- Adds dynamic behaviour for home search and enables the search