### PR TITLE
Fix reservations scoping policy

### DIFF
--- a/app/models/lab_administration.rb
+++ b/app/models/lab_administration.rb
@@ -1,19 +1,4 @@
 class LabAdministration < ApplicationRecord
   belongs_to :admin, class_name: 'User'
   belongs_to :space, polymorphic: true
-
-  validate :matches_role
-
-  private
-
-  def matches_role
-    unsupported_roles
-    errors.add(:admin, 'expected to be admin, not lab admin') if admin.lab_admin? && space_type == 'Lab'
-    errors.add(:admin, 'expected to be lab admin, not admin') if admin.admin? && space_type == 'LabSpace'
-  end
-
-  def unsupported_roles
-    errors.add(:admin, 'cannot be user') if admin.user?
-    errors.add(:admin, 'cannot be superadmin, it already has all privileges') if admin.superadmin?
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,15 +26,18 @@ class User < ApplicationRecord
   has_many :directly_managed_reservations, through: :directly_managed_equipment, source: :reservations
 
   def managed_lab_spaces
-    LabSpace.find_by_sql("(#{directly_managed_lab_spaces.to_sql}) UNION (#{indirectly_managed_lab_spaces.to_sql})")
+    lab_spaces = LabSpace.find_by_sql("(#{directly_managed_lab_spaces.to_sql}) UNION (#{indirectly_managed_lab_spaces.to_sql})")
+    LabSpace.where(id: lab_spaces.map(&:id))
   end
 
   def managed_equipment
-    LabSpace.find_by_sql("(#{directly_managed_equipment.to_sql}) UNION (#{indirectly_managed_equipment.to_sql})")
+    equipment = Equipment.find_by_sql("(#{directly_managed_equipment.to_sql}) UNION (#{indirectly_managed_equipment.to_sql})")
+    Equipment.where(id: equipment.map(&:id))
   end
 
   def managed_reservations
-    LabSpace.find_by_sql("(#{directly_managed_reservations.to_sql}) UNION (#{indirectly_managed_reservations.to_sql})")
+    reservations = Reservation.find_by_sql("(#{directly_managed_reservations.to_sql}) UNION (#{indirectly_managed_reservations.to_sql})")
+    Reservation.where(id: reservations.map(&:id))
   end
 
   def manages?(managed)

--- a/app/policies/reservation_policy.rb
+++ b/app/policies/reservation_policy.rb
@@ -8,7 +8,7 @@ class ReservationPolicy < ApplicationPolicy
   end
 
   def create?
-    default_authorization
+    true
   end
 
   def update?
@@ -30,9 +30,7 @@ class ReservationPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       return scope.all if user.superadmin?
-      return user.indirectly_managed_reservations if user.admin?
-      return user.directly_managed_reservations if user.lab_admin?
-
+      return user.managed_reservations if user.admin? || user.lab_admin?
       user.reservations
     end
   end


### PR DESCRIPTION
- Changes managed_* query to redo query with id's instead of returning array
- Authorizes new/create reservation without restriction
- Removes role restriction for lab administration.