### PR TITLE
Redirect to root when attempting to access unauthorized action

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -10,6 +10,7 @@ module Admin
     before_action :authenticate_user!
     before_action :authorize_admin
     before_action :set_locale
+    rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
     helper all_helpers_from_path 'app/helpers'
 
@@ -19,6 +20,10 @@ module Admin
 
     def authorize_admin
       authorize :admin, :show?
+    end
+
+    def user_not_authorized
+      redirect_to root_path
     end
 
     # Override this value to specify the number of elements to display at a time

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,9 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_locale
   include Pundit
-  protect_from_forgery
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   protected
 
@@ -18,5 +19,9 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:account_update) do |user|
       user.permit(:given_name, :last_name, :email, :institutional_id, :password, :password_confirmation, :current_password)
     end
+  end
+
+  def user_not_authorized
+    redirect_to root_path
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,8 +14,6 @@ module Makersprogram
     config.i18n.default_locale = :en
     # config.assets.enabled = false
 
-    config.action_dispatch.rescue_responses["Pundit::NotAuthorizedError"] = :forbidden
-
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
- Change `Pundit::NotAuthorizedError` behavior: redirect to root instead of responding with `:forbidden` (403).