### PR TITLE
Changes to dashboard and how materials/capabilities are destroyed

### DIFF
--- a/app/controllers/equipment_controller.rb
+++ b/app/controllers/equipment_controller.rb
@@ -90,8 +90,6 @@ class EquipmentController < ApplicationController
 
   def update_relations(type)
     @equipment.try(type).clear
-    class_type = type.classify.safe_constantize
-    class_type.try(:orphaned).try(:destroy_all)
     save_relations(type)
   end
 

--- a/app/controllers/equipment_controller.rb
+++ b/app/controllers/equipment_controller.rb
@@ -87,7 +87,7 @@ class EquipmentController < ApplicationController
   end
 
   def update_relations(type)
-    @equipment.try(type).clear
+    @equipment.try(type).destroy_all
     save_relations(type)
   end
 

--- a/app/controllers/equipment_controller.rb
+++ b/app/controllers/equipment_controller.rb
@@ -2,9 +2,7 @@ class EquipmentController < ApplicationController
   before_action :set_parent_lab_space
   before_action :set_equipment, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!, except: [:index, :show]
-  before_action do
-    authorize @equipment || @equipment_scope.new
-  end
+  before_action { authorize(@equipment || @equipment_scope.new) }
 
   # GET /lab/1/lab_spaces/1/equipment
   # GET /equipment.json

--- a/app/models/capability.rb
+++ b/app/models/capability.rb
@@ -1,7 +1,10 @@
 class Capability < ApplicationRecord
   has_many :equipment_capabilities
   has_many :equipment, through: :equipment_capabilities
-  scope :orphaned, -> { left_outer_joins(:equipment_capabilities).where(equipment_capabilities: { id: nil }) }
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
+
+  def destroy_if_orphaned
+    destroy if equipment_capabilities.empty?
+  end
 end

--- a/app/models/equipment_capability.rb
+++ b/app/models/equipment_capability.rb
@@ -3,4 +3,8 @@ class EquipmentCapability < ApplicationRecord
   belongs_to :equipment
 
   validates :capability, :equipment, presence: true
+
+  def destroy_orphaned(record)
+    record.capability.destroy_if_orphaned
+  end
 end

--- a/app/models/equipment_capability.rb
+++ b/app/models/equipment_capability.rb
@@ -2,6 +2,7 @@ class EquipmentCapability < ApplicationRecord
   belongs_to :capability
   belongs_to :equipment
   validates :capability, :equipment, presence: true
+  validates_uniqueness_of :capability_id, scope: :equipment_id
   after_destroy :destroy_orphaned
 
   def destroy_orphaned

--- a/app/models/equipment_capability.rb
+++ b/app/models/equipment_capability.rb
@@ -1,10 +1,10 @@
 class EquipmentCapability < ApplicationRecord
   belongs_to :capability
   belongs_to :equipment
-
   validates :capability, :equipment, presence: true
+  after_destroy :destroy_orphaned
 
-  def destroy_orphaned(record)
-    record.capability.destroy_if_orphaned
+  def destroy_orphaned
+    material.destroy_if_orphaned
   end
 end

--- a/app/models/equipment_material.rb
+++ b/app/models/equipment_material.rb
@@ -2,6 +2,7 @@ class EquipmentMaterial < ApplicationRecord
   belongs_to :material
   belongs_to :equipment
   validates :material, :equipment, presence: true
+  validates_uniqueness_of :material_id, scope: :equipment_id
   after_destroy :destroy_orphaned
 
   def destroy_orphaned

--- a/app/models/equipment_material.rb
+++ b/app/models/equipment_material.rb
@@ -2,9 +2,9 @@ class EquipmentMaterial < ApplicationRecord
   belongs_to :material
   belongs_to :equipment
   validates :material, :equipment, presence: true
-  after_destroy ->(record) { destroy_orphaned(record) }
+  after_destroy :destroy_orphaned
 
-  def destroy_orphaned(record)
-    record.material.destroy_if_orphaned
+  def destroy_orphaned
+    material.destroy_if_orphaned
   end
 end

--- a/app/models/equipment_material.rb
+++ b/app/models/equipment_material.rb
@@ -1,6 +1,10 @@
 class EquipmentMaterial < ApplicationRecord
   belongs_to :material
   belongs_to :equipment
-
   validates :material, :equipment, presence: true
+  after_destroy ->(record) { destroy_orphaned(record) }
+
+  def destroy_orphaned(record)
+    record.material.destroy_if_orphaned
+  end
 end

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -1,7 +1,10 @@
 class Material < ApplicationRecord
   has_many :equipment_materials
   has_many :equipment, through: :equipment_materials
-  scope :orphaned, -> { left_outer_joins(:equipment_materials).where(equipment_materials: { id: nil }) }
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
+
+  def destroy_if_orphaned
+    destroy if equipment_materials.empty?
+  end
 end

--- a/app/policies/dashboard_policy.rb
+++ b/app/policies/dashboard_policy.rb
@@ -11,11 +11,11 @@ class DashboardPolicy
   end
 
   def available_hours?
-    !user.user?
+    false
   end
 
   def capabilities?
-    !user.user?
+    false
   end
 
   def equipment?
@@ -39,7 +39,7 @@ class DashboardPolicy
   end
 
   def materials?
-    !user.user?
+    false
   end
 
   def reservations?

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -60,7 +60,7 @@
     </div>
     <div class="row">
       <div class="col">
-        <h2 class="mb-2">Ficha t&eacute;cnica</h2>
+        <h2 class="mb-2">Descripci&oacute;n t&eacute;cnica</h2>
         <p><%= @equipment.technical_description %></p>
       </div>
     </div>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -25,6 +25,10 @@
     <ul class="navList dropdown-menu dropdown-menu-right animate slideIn" aria-labelledby="navbarDropdown">
       <li><%= link_to "Inicio", root_path, class: 'dropdown-item' %></li>
       <li><div class="dropdown-divider"></div></li>
+      <% if policy(:admin).show? %>
+        <li><%= link_to "Admin Dashboard", admin_root_path, class: 'dropdown-item' %></li>
+      <% end %>
+      <li><div class="dropdown-divider"></div></li>
       <% if user_signed_in? %>
         <li><%= link_to "Mis reservaciones", profile_path, class: 'dropdown-item' %></li>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,18 @@
 Rails.application.routes.draw do
   namespace :admin do
-      resources :users
-      resources :available_hours
-      resources :capabilities
       resources :equipment
-      resources :equipment_capabilities
-      resources :equipment_materials
       resources :labs
       resources :lab_spaces
-      resources :materials
       resources :reservations
+      resources :users
       resources :lab_administrations
+
+      # Resources not shown on dashboard, but needed for forms
+      resources :available_hours
+      resources :capabilities
+      resources :materials
+      resources :equipment_capabilities
+      resources :equipment_materials
 
       root to: "users#index"
   end

--- a/spec/policies/dashboard_policy_spec.rb
+++ b/spec/policies/dashboard_policy_spec.rb
@@ -16,36 +16,23 @@ RSpec.describe DashboardPolicy, type: :policy do
   context 'for a superadmin' do
     let(:user) { create(:user, role: :superadmin) }
 
-    it { should forbid_actions [:equipment_capabilities, :equipment_materials] }
-
-    it {
-      should permit_actions [:users, :available_hours, :capabilities, :equipment,
-                             :labs, :lab_spaces, :materials, :reservations, :lab_administrations]
-    }
+    it { should forbid_actions [:equipment_capabilities, :equipment_materials, :materials, :available_hours, :capabilities] }
+    it { should permit_actions [:users, :equipment, :labs, :lab_spaces, :reservations, :lab_administrations] }
   end
 
   context 'for an admin' do
     let(:user) { create(:user, role: :admin) }
 
-    it { should forbid_actions [:equipment_capabilities, :equipment_materials] }
-
-    it {
-      should permit_actions [:users, :available_hours, :capabilities, :equipment,
-                             :labs, :lab_spaces, :materials, :reservations, :lab_administrations]
-    }
+    it { should forbid_actions [:equipment_capabilities, :equipment_materials, :materials, :available_hours, :capabilities] }
+    it { should permit_actions [:users, :equipment, :labs, :lab_spaces, :reservations, :lab_administrations] }
   end
 
   context 'for a lab admin' do
     let(:user) { create(:user, role: :lab_admin) }
 
-    it { should forbid_actions [:equipment_capabilities, :equipment_materials] }
-
+    it { should forbid_actions [:equipment_capabilities, :equipment_materials, :available_hours, :capabilities, :materials] }
     it { should forbid_actions [:labs, :lab_administrations] }
-
-    it {
-      should permit_actions [:users, :available_hours, :capabilities, :equipment,
-                             :lab_spaces, :materials, :reservations]
-    }
+    it { should permit_actions [:users,  :equipment, :lab_spaces, :reservations] }
   end
 
   context 'for a lab admin that manages a lab' do
@@ -56,13 +43,12 @@ RSpec.describe DashboardPolicy, type: :policy do
       lab_admin
     end
 
-    it { should forbid_actions [:equipment_capabilities, :equipment_materials] }
+    it { should forbid_actions [:equipment_capabilities, :equipment_materials, :available_hours, :capabilities, :materials] }
 
     it { should forbid_actions [:lab_administrations] }
 
     it {
-      should permit_actions [:users, :available_hours, :capabilities, :equipment,
-                             :labs, :lab_spaces, :materials, :reservations]
+      should permit_actions [:users, :equipment, :labs, :lab_spaces, :reservations]
     }
   end
 end


### PR DESCRIPTION
- agregar link para admins a navbar
- material/capability validation of `uniqueness`
- mover validación de borrar `orphaned` material/capability como `after_destroy` callback de las asociaciones, en lugar de realizarlo en los controladores
- cambiar orden de dashboard, equipment hasta arriba
- materiales/capability/available_hours no debería de aparecer en dashboard
- ficha técnica -> descripción técnica

Related: #79 