### PR TITLE
Fix disable equipment

### DIFF
--- a/app/controllers/admin/equipment_controller.rb
+++ b/app/controllers/admin/equipment_controller.rb
@@ -15,6 +15,13 @@ module Admin
     #   Equipment.find_by!(slug: param)
     # end
 
+    def destroy
+      @equipment = Equipment.find(params[:id])
+      @equipment.update_attribute(:hidden, true)
+      flash[:notice] = 'Equipment was successfully hidden.'
+      redirect_to admin_equipment_index_path
+    end
+
     # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
     # for more information
   end

--- a/app/controllers/admin/equipment_controller.rb
+++ b/app/controllers/admin/equipment_controller.rb
@@ -17,8 +17,8 @@ module Admin
 
     def destroy
       @equipment = Equipment.find(params[:id])
-      @equipment.update_attribute(:hidden, true)
-      flash[:notice] = 'Equipment was successfully hidden.'
+      @equipment.update_attribute(:hidden, !@equipment.hidden)
+      flash[:notice] = "Equipment was successfully #{@equipment.hidden ? 'hidden' : 'unhidden'}."
       redirect_to admin_equipment_index_path
     end
 

--- a/app/controllers/equipment_controller.rb
+++ b/app/controllers/equipment_controller.rb
@@ -7,14 +7,15 @@ class EquipmentController < ApplicationController
   # GET /lab/1/lab_spaces/1/equipment
   # GET /equipment.json
   def index
-    @equipment_scope = @equipment_scope.search(params[:equipment_query])
-    @equipment_scope = @equipment_scope.search_by(:materials, params[:materials_query])
-    @equipment_scope = @equipment_scope.search_by(:capabilities, params[:capabilities_query])
+    @equipment_scope = @equipment_scope.visible.search(params[:equipment_query])
+    @equipment_scope = @equipment_scope.visible.search_by(:materials, params[:materials_query])
+    @equipment_scope = @equipment_scope.visible.search_by(:capabilities, params[:capabilities_query])
   end
 
   # GET /lab/1/lab_spaces/1/equipment/1
   # GET /lab/1/lab_spaces/1/equipment/1.json
   def show
+    redirect_to root_path if @equipment.hidden
   end
 
   # GET /lab/1/lab_spaces/1/equipment/new

--- a/app/controllers/equipment_controller.rb
+++ b/app/controllers/equipment_controller.rb
@@ -7,9 +7,9 @@ class EquipmentController < ApplicationController
   # GET /lab/1/lab_spaces/1/equipment
   # GET /equipment.json
   def index
-    @equipment_scope = @equipment_scope.visible.search(params[:equipment_query])
-    @equipment_scope = @equipment_scope.visible.search_by(:materials, params[:materials_query])
-    @equipment_scope = @equipment_scope.visible.search_by(:capabilities, params[:capabilities_query])
+    @equipment_scope = @equipment_scope.search(params[:equipment_query])
+    @equipment_scope = @equipment_scope.search_by(:materials, params[:materials_query])
+    @equipment_scope = @equipment_scope.search_by(:capabilities, params[:capabilities_query])
   end
 
   # GET /lab/1/lab_spaces/1/equipment/1
@@ -73,9 +73,9 @@ class EquipmentController < ApplicationController
   def set_parent_lab_space
     if params[:lab_space_id]
       @lab_space = LabSpace.find(params[:lab_space_id])
-      @equipment_scope = @lab_space.equipment
+      @equipment_scope = @lab_space.equipment.visible
     else
-      @equipment_scope = Equipment.all
+      @equipment_scope = Equipment.all.visible
     end
   end
 

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -1,5 +1,6 @@
 class Equipment < ApplicationRecord
   audited
+
   mount_uploader :image, ImageUploader
 
   has_many :equipment_materials, dependent: :destroy
@@ -13,6 +14,8 @@ class Equipment < ApplicationRecord
   validates :name, :description, :lab_space, presence: true
 
   accepts_nested_attributes_for :available_hours
+
+  scope :visible, -> {where(:hidden => false)}
 
   def self.search(name)
     if name.present?

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -15,7 +15,7 @@ class Equipment < ApplicationRecord
 
   accepts_nested_attributes_for :available_hours
 
-  scope :visible, -> {where(:hidden => false)}
+  scope :visible, -> { where(hidden: false) }
 
   def self.search(name)
     if name.present?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -22,9 +22,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def destroy?
-    return false unless user
-
-    user.id == record.id || user.superadmin?
+    false
   end
 
   class Scope < Scope

--- a/app/views/admin/equipment/_collection.html.erb
+++ b/app/views/admin/equipment/_collection.html.erb
@@ -82,7 +82,7 @@ to display a collection of resources in an HTML table.
 
         <% if valid_action? :destroy, collection_presenter.resource_name %>
           <td><%= link_to(
-            t("Hide"),
+            t(resource.hidden ? "Un Hide" : "Hide"),
             [namespace, resource],
             class: "text-color-red",
             method: :delete,

--- a/app/views/admin/equipment/_collection.html.erb
+++ b/app/views/admin/equipment/_collection.html.erb
@@ -1,0 +1,95 @@
+<%#
+# Collection
+
+This partial is used on the `index` and `show` pages
+to display a collection of resources in an HTML table.
+
+## Local variables:
+
+- `collection_presenter`:
+  An instance of [Administrate::Page::Collection][1].
+  The table presenter uses `ResourceDashboard::COLLECTION_ATTRIBUTES` to determine
+  the columns displayed in the table
+- `resources`:
+  An ActiveModel::Relation collection of resources to be displayed in the table.
+  By default, the number of resources is limited by pagination
+  or by a hard limit to prevent excessive page load times
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<table aria-labelledby="<%= table_title %>">
+  <thead>
+    <tr>
+      <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
+        <th class="cell-label
+        cell-label--<%= attr_type.html_class %>
+        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>"
+        scope="col"
+        role="columnheader"
+        aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
+        <%= link_to(sanitized_order_params(page, collection_field_name).merge(
+          collection_presenter.order_params_for(attr_name, key: collection_field_name)
+        )) do %>
+        <%= t(
+          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
+          default: attr_name.to_s,
+        ).titleize %>
+            <% if collection_presenter.ordered_by?(attr_name) %>
+              <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
+                <svg aria-hidden="true">
+                  <use xlink:href="#icon-up-caret" />
+                </svg>
+              </span>
+            <% end %>
+          <% end %>
+        </th>
+      <% end %>
+      <% [valid_action?(:edit, collection_presenter.resource_name),
+          valid_action?(:destroy, collection_presenter.resource_name)].count(true).times do %>
+        <th scope="col"></th>
+      <% end %>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% resources.each do |resource| %>
+      <tr class="js-table-row"
+          tabindex="0"
+          <% if valid_action? :show, collection_presenter.resource_name %>
+            <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) %>
+          <% end %>
+          >
+        <% collection_presenter.attributes_for(resource).each do |attribute| %>
+          <td class="cell-data cell-data--<%= attribute.html_class %>">
+            <% if show_action? :show, resource -%>
+              <a href="<%= polymorphic_path([namespace, resource]) -%>"
+                 class="action-show"
+                 >
+                <%= render_field attribute %>
+              </a>
+            <% end -%>
+          </td>
+        <% end %>
+
+        <% if valid_action? :edit, collection_presenter.resource_name %>
+          <td><%= link_to(
+            t("administrate.actions.edit"),
+            [:edit, namespace, resource],
+            class: "action-edit",
+          ) if show_action? :edit, resource%></td>
+        <% end %>
+
+        <% if valid_action? :destroy, collection_presenter.resource_name %>
+          <td><%= link_to(
+            t("Hide"),
+            [namespace, resource],
+            class: "text-color-red",
+            method: :delete,
+            data: { confirm: t("administrate.actions.confirm") }
+          ) if show_action? :destroy, resource %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/equipment/_collection.html.erb
+++ b/app/views/admin/equipment/_collection.html.erb
@@ -82,7 +82,7 @@ to display a collection of resources in an HTML table.
 
         <% if valid_action? :destroy, collection_presenter.resource_name %>
           <td><%= link_to(
-            t(resource.hidden ? "Un Hide" : "Hide"),
+            t(resource.hidden ? "Unhide" : "Hide"),
             [namespace, resource],
             class: "text-color-red",
             method: :delete,

--- a/app/views/admin/equipment/index.html.erb
+++ b/app/views/admin/equipment/index.html.erb
@@ -1,0 +1,66 @@
+<%#
+# Index
+
+This view is the template for the index page.
+It is responsible for rendering the search bar, header and pagination.
+It renders the `_table` partial to display details about the resources.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Collection][1].
+  Contains helper methods to help display a table,
+  and knows which attributes should be displayed in the resource's table.
+- `resources`:
+  An instance of `ActiveRecord::Relation` containing the resources
+  that match the user's search criteria.
+  By default, these resources are passed to the table partial to be displayed.
+- `search_term`:
+  A string containing the term the user has searched for, if any.
+- `show_search_bar`:
+  A boolean that determines if the search bar should be shown.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<% content_for(:title) do %>
+  <%= display_resource_name(page.resource_name) %>
+<% end %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title" id="page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <% if show_search_bar %>
+    <%= render(
+      "search",
+      search_term: search_term,
+      resource_name: display_resource_name(page.resource_name)
+    ) %>
+  <% end %>
+
+  <div>
+    <%= link_to(
+      t(
+        "administrate.actions.new_resource",
+        name: page.resource_name.titleize.downcase
+      ),
+      [:new, namespace, page.resource_path],
+      class: "button",
+    ) if valid_action?(:new) && show_action?(:new, new_resource) %>
+  </div>
+</header>
+
+<section class="main-content__body main-content__body--flush">
+  <%= render(
+    "collection",
+    collection_presenter: page,
+    collection_field_name: resource_name,
+    page: page,
+    resources: resources,
+    table_title: "page-title"
+  ) %>
+
+  <%= paginate resources %>
+</section>

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -85,6 +85,10 @@
           </div>
           <div class="modal-body">
             <div class="form-group">
+              <p>Horario de reservaci&oacute;n:</br>
+                <small id="tmpEventStartDisplay"></small></br>
+                <small id="tmpEventEndDisplay"></small>
+              </p>
               <label class="ttu" for="purpose"><strong>Prop&oacute;sito del proyecto <small>(Requerido)</small></strong></label>
               <select name="purpose" class="form-control" id="purpose">
                 <option value="academic">Academia</option>
@@ -170,6 +174,8 @@
               start: selInfo.start,
               end: selInfo.end,
             };
+            $('#tmpEventStartDisplay').html(selInfo.start.toDateString() +" "+ selInfo.start.toLocaleTimeString())
+            $('#tmpEventEndDisplay').html(selInfo.end.toDateString() +" "+ selInfo.end.toLocaleTimeString())
           },
           businessHours: bhours,
           eventRender: function(info) {

--- a/app/views/lab_spaces/show.html.erb
+++ b/app/views/lab_spaces/show.html.erb
@@ -59,7 +59,7 @@
     <h2>Equipo</h2>
     <div class="EquipoGrid">
       <div class="row">
-        <% @lab_space.equipment.each do |e| %>
+        <% @lab_space.equipment.visible.each do |e| %>
             <div class="col-4">
               <div class="EquipoCard" data-id="<%= e.id %>" data-lid="<%= @lab_space.lab.id %>" data-lsid="<%= @lab_space.id %>">
                 <div class="icon printer"></div>

--- a/db/migrate/20190513160249_add_hidden_to_equipment.rb
+++ b/db/migrate/20190513160249_add_hidden_to_equipment.rb
@@ -1,0 +1,5 @@
+class AddHiddenToEquipment < ActiveRecord::Migration[5.2]
+  def change
+    add_column :equipment, :hidden, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_26_061548) do
+ActiveRecord::Schema.define(version: 2019_05_13_160249) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 2019_04_26_061548) do
     t.datetime "updated_at", null: false
     t.bigint "lab_space_id"
     t.text "technical_description"
+    t.boolean "hidden", default: false
     t.index ["lab_space_id"], name: "index_equipment_on_lab_space_id"
   end
 


### PR DESCRIPTION
- Added a `hidden` field for equipments instead of `destroy`.

- Added a `visible` scope to `equipment`, this returns equipment that is not hidden 🦆 
- Added date/time info in reservation modal
- Remove destroy user policy for all users

Hiding an equipment means users cannot see the equipment when navigating the main page.
