### PR TITLE
Enable add hours in external and internal page

### DIFF
--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -432,3 +432,10 @@ h1 {
   font-size: 1.45rem;
   width: 100%;
 }
+
+.fc-unthemed td.fc-today {
+  background: #fff !important;
+}
+.fc-unthemed th.fc-today {
+  background-color: #fcf8e3;
+}

--- a/app/views/admin/equipment/_form.html.erb
+++ b/app/views/admin/equipment/_form.html.erb
@@ -20,10 +20,10 @@ and renders all form fields for a resource's editable attributes.
     <i class="ico calendar"></i>
     <p class="content">
       Todos los
-      <select class="inline dow_select" name="day" id="day" value="0"> <%# TODO: make this multiple! %>
+      <select class="inline dow_select" name="day" id="day">
         <option value="0">d&iacute;as (diario)</option>
         <option value="1">d&iacute;as (Lu-Vie)</option>
-        <option value="2">Lunes</option>
+        <option selected value="2">Lunes</option>
         <option value="3">Martes</option>
         <option value="4">Mi&eacute;rcoles</option>
         <option value="5">Jueves</option>
@@ -97,6 +97,8 @@ and renders all form fields for a resource's editable attributes.
       const $scheduleList = $('.scheduleList');
       let data = false;
       const dateMap = {
+        0: "diario",
+        1: "luvi",
         2: "monday",
         3: "tuesday",
         4: "wednesday",
@@ -122,6 +124,8 @@ and renders all form fields for a resource's editable attributes.
         });
         $('form').on('submit', function(e) {
           e.preventDefault();
+          console.log(document);
+          checkDOW();
           $('input.start_time, input.end_time').each(function(index, item) {
             item.value = item.value + ' CT';
           });
@@ -139,6 +143,7 @@ and renders all form fields for a resource's editable attributes.
         const clone = document.importNode(horarioTpl.content, true);
         const $clone = $(clone);
         const id = index === null || index === undefined ? new Date().getTime() : index;
+
         const start_input = document.createElement('input');
         start_input.classList.add("start_time");
         start_input.type = "hidden";
@@ -204,6 +209,49 @@ and renders all form fields for a resource's editable attributes.
         e.preventDefault();
         generateAH();
       });
+
+      function checkDOW() {
+        $('.scheduleList-listitem').each((index, item) => {
+          const $item = $(item);
+          let $dow = $item.find('input.day_of_week');
+          if($dow.length <= 0) return false;
+          let val = $dow.val();
+          if(val != 'luvi' && val != 'diario') {
+            return true;
+          }
+          let st = $item.find('input.start_time').val();
+          let et = $item.find('input.end_time').val();
+          $item.find('input[type="hidden"]').remove();
+          let top = 0;
+          if(val == "luvi") {
+            top = 5;
+          }
+          else if(val == "diario") {
+            top = 7;
+          }
+          for(let i = 0; i < top; i++) {
+            let id = new Date().getTime();
+            const start_input = document.createElement('input');
+            start_input.classList.add("start_time");
+            start_input.type = "hidden";
+            start_input.name = `equipment[available_hours_attributes][${id}][start_time]`;
+            start_input.value = st;
+
+            const end_input = document.createElement('input');
+            end_input.classList.add("end_time");
+            end_input.type = "hidden";
+            end_input.name = `equipment[available_hours_attributes][${id}][end_time]`;
+            end_input.value = et;
+
+            const dow_input = document.createElement('input');
+            dow_input.classList.add("day_of_week");
+            dow_input.type = "hidden";
+            dow_input.name = `equipment[available_hours_attributes][${id}][day_of_week]`;
+            dow_input.value = dateMap[i+2];
+            $item.append([start_input, dow_input, end_input]);
+          }
+        });
+      }
     </script>
   <% end %>
 <% end %>

--- a/app/views/home/landing.html.erb
+++ b/app/views/home/landing.html.erb
@@ -20,7 +20,7 @@
       </div>
       <a href="#" class="logo">
         <%= image_tag "logo.svg", alt: "Makers Program" %>
-        <p class="tecbrand">@Tec de Monterrey</p>
+        <p class="tecbrand">sponsored by Innovaction Gym</p>
       </a>
       <h2 class="tagline">&iquest;Qu&eacute; quieres crear hoy?</h2>
       <div class="QueryBuilder">

--- a/app/views/lab_spaces/show.html.erb
+++ b/app/views/lab_spaces/show.html.erb
@@ -125,7 +125,7 @@
                   <select name="day" id="day" value="0"> <%# TODO: make this multiple! %>
                     <option value="0">d&iacute;as (diario)</option>
                     <option value="1">d&iacute;as (Lu-Vie)</option>
-                    <option value="2">Lunes</option>
+                    <option selected value="2">Lunes</option>
                     <option value="3">Martes</option>
                     <option value="4">Mi&eacute;rcoles</option>
                     <option value="5">Jueves</option>
@@ -243,6 +243,8 @@
     $EquipoForm = $('.EquipoForm');
 
     const dateMap = {
+      0: "diario",
+      1: "luvi",
       2: "monday",
       3: "tuesday",
       4: "wednesday",
@@ -267,12 +269,11 @@
       const dayindex = parseInt($selectDay.val(), 10);
       const days = dayOptions[dayindex];
 
-      if(dayindex === 0 || dayindex === 1) {
-        console.log("Can't handle that option yet");
+      // TODO: validate that endTime is > startTime
+      if(startTime == endTime) {
+        alert("La hora de inicio no puede ser igual que la hora de fin.");
         return false;
       }
-      // TODO: validate that endTime is > startTime
-      console.log(startTime, endTime);
 
       const dayObj = {
         start_time: startTime,
@@ -280,7 +281,18 @@
         day_of_week: dateMap[dayindex]
       };
 
-      let scheduleStr = `Todos los <strong>${days}</strong> de <strong>${startTime} a ${endTime}</strong>`;
+      let scheduleStr = "";
+      if(dayObj.day_of_week === "diario") {
+        scheduleStr = 'Diario (Lun.-Dom.) ';
+      }
+      else if(dayObj.day_of_week === "luvi") {
+        scheduleStr = "Lunes a viernes ";
+      }
+      else {
+        scheduleStr = `Todos los <strong>${days}</strong> `;
+      }
+      scheduleStr += `de <strong>${startTime} a ${endTime}</strong>`;
+
       let $listItem = $('.scheduleList-listitem').first().clone();
       $listItem.data('index', availSchedule.length);
       $listItem.css('display', 'block');
@@ -327,13 +339,33 @@
       for(var key in formData) {
         fd.append(`equipment[${key}]`, formData[key]);
       }
+      var n = 0;
       for (var i = 0; i < availSchedule.length; i++) {
         if(availSchedule[i] === undefined) {
           continue;
         }
-        fd.append(`equipment[available_hours][${i}][day_of_week]`, availSchedule[i]['day_of_week']);
-        fd.append(`equipment[available_hours][${i}][start_time]`, availSchedule[i]['start_time'] + ' CT');
-        fd.append(`equipment[available_hours][${i}][end_time]`, availSchedule[i]['end_time'] + ' CT');
+        if(availSchedule[i]['day_of_week'] == 'luvi') {
+          for(let j = 0; j < 5; j++) {
+            fd.append(`equipment[available_hours][${n+j}][day_of_week]`, dateMap[j+2]);
+            fd.append(`equipment[available_hours][${n+j}][start_time]`, availSchedule[i]['start_time'] + ' CT');
+            fd.append(`equipment[available_hours][${n+j}][end_time]`, availSchedule[i]['end_time'] + ' CT');
+          }
+          n += 4;
+        }
+        if(availSchedule[i]['day_of_week'] == 'diario') {
+          for(let j = 0; j < 7; j++) {
+            fd.append(`equipment[available_hours][${n+j}][day_of_week]`, dateMap[j+2]);
+            fd.append(`equipment[available_hours][${n+j}][start_time]`, availSchedule[i]['start_time'] + ' CT');
+            fd.append(`equipment[available_hours][${n+j}][end_time]`, availSchedule[i]['end_time'] + ' CT');
+          }
+          n += 6;
+        }
+        else {
+          fd.append(`equipment[available_hours][${n}][day_of_week]`, availSchedule[i]['day_of_week']);
+          fd.append(`equipment[available_hours][${n}][start_time]`, availSchedule[i]['start_time'] + ' CT');
+          fd.append(`equipment[available_hours][${n}][end_time]`, availSchedule[i]['end_time'] + ' CT');
+        }
+        n++;
       }
       fd.append("authenticity_token", $('meta[name=csrf-token]').attr('content'));
 
@@ -362,10 +394,9 @@
           // Add the new equipment card
           const clone = document.importNode($equipoCardTpl[0].content, true);
           const $clone = $(clone);
-          $clone.find('.EquipoCard').attr('data-id', newid).attr('data-lsid', _lsid).attr('data-lid', _lid);
+          $clone.find('.EquipoCard').data('id', newid).data('lsid', _lsid).data('lid', _lid).click(bindEquipment);
           $clone.find('.name').html(name);
           // Bind
-          $clone.click(bindEquipment);
           $('#addEquip').parent().before($clone);
           $('.EquipoForm').fadeOut(function() {
             $('.EquipoGrid').fadeIn();

--- a/app/views/lab_spaces/show.html.erb
+++ b/app/views/lab_spaces/show.html.erb
@@ -122,7 +122,7 @@
 
               <li id="addScheduleForm" class="NewSchedule" style="display: none">
                 <p>Todos los
-                  <select name="day" id="day" value="0"> <%# TODO: make this multiple! %>
+                  <select name="day" id="day">
                     <option value="0">d&iacute;as (diario)</option>
                     <option value="1">d&iacute;as (Lu-Vie)</option>
                     <option selected value="2">Lunes</option>
@@ -228,7 +228,7 @@
       e.preventDefault();
       let $form = $('#addScheduleForm');
       $form.find('select').each(function() {
-        $(this).prop('selectedIndex', 0);
+        $(this).prop('selectedIndex', 2);
       });
       $form.slideDown('fast');
     });
@@ -352,7 +352,7 @@
           }
           n += 4;
         }
-        if(availSchedule[i]['day_of_week'] == 'diario') {
+        else if(availSchedule[i]['day_of_week'] == 'diario') {
           for(let j = 0; j < 7; j++) {
             fd.append(`equipment[available_hours][${n+j}][day_of_week]`, dateMap[j+2]);
             fd.append(`equipment[available_hours][${n+j}][start_time]`, availSchedule[i]['start_time'] + ' CT');


### PR DESCRIPTION
This PR:

- Enables diario and lu-vi in external and dashboard pages
- Fixes the card click event upon creation in external page when creating a new equipment