### PR TITLE
Upcoming reservations changes

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,7 @@
 class HomeController < ApplicationController
   config.cache_store = :null_store
   before_action :authenticate_user!, except: [:landing]
+
   def landing
     @body_class = 'Home'
     @capabilities = Capability.all
@@ -10,6 +11,6 @@ class HomeController < ApplicationController
   end
 
   def profile
-    @reservations = current_user.reservations.confirmed
+    @reservations = current_user.reservations.confirmed.future
   end
 end

--- a/app/dashboards/equipment_dashboard.rb
+++ b/app/dashboards/equipment_dashboard.rb
@@ -21,6 +21,7 @@ class EquipmentDashboard < Administrate::BaseDashboard
     reservations: Field::NestedHasMany,
     updated_at: Field::DateTime,
     technical_description: Field::Text,
+    upcoming_reservations: Field::Number,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -31,6 +32,7 @@ class EquipmentDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = [
     :name,
     :lab_space,
+    :upcoming_reservations,
     :created_at,
     :updated_at,
   ].freeze

--- a/app/dashboards/lab_administration_dashboard.rb
+++ b/app/dashboards/lab_administration_dashboard.rb
@@ -24,7 +24,6 @@ class LabAdministrationDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = [
     :admin,
     :space,
-    :id,
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES

--- a/app/dashboards/reservation_dashboard.rb
+++ b/app/dashboards/reservation_dashboard.rb
@@ -11,7 +11,7 @@ class ReservationDashboard < Administrate::BaseDashboard
     equipment: Field::BelongsToSearch.with_options(searchable: true, searchable_field: 'name'),
     user: Field::BelongsToSearch.with_options(searchable: true, searchable_field: 'given_name'),
     id: Field::Number,
-    status: Field::Select.with_options(searchable: false, collection: Reservation.statuses.keys),
+    status: Field::Select.with_options(searchable: false, collection: Reservation.statuses.keys - ['blocked']),
     purpose: Field::Select.with_options(searchable: false, collection: Reservation.purposes.keys),
     comment: Field::Text,
     start_time: Field::DateTime,
@@ -37,14 +37,11 @@ class ReservationDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = [
     :equipment,
     :user,
-    :id,
     :status,
     :purpose,
     :comment,
     :start_time,
-    :end_time,
-    :created_at,
-    :updated_at,
+    :end_time
   ].freeze
 
   # FORM_ATTRIBUTES

--- a/app/dashboards/reservation_dashboard.rb
+++ b/app/dashboards/reservation_dashboard.rb
@@ -26,10 +26,11 @@ class ReservationDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
-    :equipment,
     :user,
-    :id,
+    :equipment,
     :status,
+    :start_time,
+    :end_time
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -37,26 +37,17 @@ class UserDashboard < Administrate::BaseDashboard
     :given_name,
     :last_name,
     :email,
-    :role,
-    :created_at,
-    :updated_at,
+    :role
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = [
-    :institutional_id,
     :given_name,
     :last_name,
     :email,
+    :institutional_id,
     :role,
-    :reset_password_sent_at,
-    :remember_created_at,
-    :confirmation_token,
-    :confirmed_at,
-    :confirmation_sent_at,
-    :created_at,
-    :updated_at,
     :reservations,
   ].freeze
 

--- a/app/mailers/makers_mailer.rb
+++ b/app/mailers/makers_mailer.rb
@@ -1,0 +1,8 @@
+class MakersMailer < ApplicationMailer
+  default from: 'makersprogram-noreply@tec.mx'
+
+  def cancellation_email(reservation)
+    @reservation = reservation
+    mail(to: @reservation.user.email, subject: 'Tu reservación ha sido cancelada.')
+  end
+end

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -38,4 +38,8 @@ class Equipment < ApplicationRecord
   def self.capabilities
     Capability.joins(:equipment).where(equipment: { id: ids })
   end
+
+  def upcoming_reservations
+    reservations.future.count
+  end
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -12,7 +12,7 @@ class Reservation < ApplicationRecord
   scope :upcoming, ->(limit) { where('start_time > ?', Time.now).order(:start_time).limit(limit) }
   scope :future, -> { where('start_time > ?', Time.now).order(:start_time) }
 
-  after_save :check_cancellation
+  after_save :check_cancellation, if: -> { previous_changes.include?(:status) }
 
   def overlapped_reservations
     equipment.reservations

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -63,7 +63,7 @@ class Reservation < ApplicationRecord
   end
 
   def remove_overlapped
-    overlapped_reservations.each(&:cancelled!) # TODO: notify user of cancellation
+    overlapped_reservations.each(&:cancelled!)
   end
 
   def date_range_valid

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -10,6 +10,7 @@ class Reservation < ApplicationRecord
   validate :date_is_available, on: :create
 
   scope :upcoming, ->(limit) { where('start_time > ?', Time.now).order(:start_time).limit(limit) }
+  scope :future, -> { where('start_time > ?', Time.now).order(:start_time) }
 
   after_save :check_cancellation
 

--- a/app/views/admin/equipment/show.html.erb
+++ b/app/views/admin/equipment/show.html.erb
@@ -65,23 +65,17 @@ as well as a link to its edit page.
                 <h4 class="card-title">Upcoming reservations</h4>
                 <table class="ReservationTable">
                   <tbody>
-                    <%# TODO: filtra solo las de hoy %>
-                    <% res = page.resource.reservations.confirmed %>
+                    <% res = page.resource.reservations.confirmed.upcoming(5) %>
                     <% if res.length == 0 %>
                       <p>No upcoming reservations</p>
                     <% else %>
                       <% res.each do | r |  %>
-                        <tr>
+                        <tr onclick="window.location='<%= admin_reservation_path(r) %>';">
                           <td><%= link_to "#{r.user.given_name} #{r.user.last_name}", admin_user_path(r.user) %></td>
+                          <td><%= r.start_time.strftime("%A %d/%m") %></td>
                           <td><%= r.start_time.in_time_zone('America/Monterrey').to_formatted_s(:time) %></td>
                           <td><%= r.end_time.in_time_zone('America/Monterrey').to_formatted_s(:time) %></td>
-                          <td>
-                            <select name="reservation_status" id="reservation_status">
-                              <option <%= r.status == "confirmed" ? 'selected' : '' %> value="confirmed">Confirmed</option>
-                              <option <%= r.status == "complete" ? 'selected' : '' %> value="complete">Complete</option>
-                              <option <%= r.status == "cancelled" ? 'selected' : '' %> value="cancelled">Cancelled</option>
-                            </select>
-                          </td>
+                          <td><%= r.status %></td>
                         </tr>
                       <% end %>
                     <% end %>

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -87,7 +87,7 @@
             <div class="form-group">
               <label class="ttu" for="purpose"><strong>Prop&oacute;sito del proyecto <small>(Requerido)</small></strong></label>
               <select name="purpose" class="form-control" id="purpose">
-                <option value="academic">Academia</option>
+                <option value="academic">Académico</option>
                 <option value="entrepreneurship">Emprendimiento</option>
                 <option value="research">Investigaci&oacute;n</option>
                 <option value="personal">Personal</option>

--- a/app/views/makers_mailer/cancellation_email.html.erb
+++ b/app/views/makers_mailer/cancellation_email.html.erb
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+</head>
+<body>
+<p>Hola <%= @reservation.user.given_name %>,</p>
+<p>
+  Tu reservación del equipo <%= @reservation.equipment.name %>
+  para el día <%= @reservation.start_time.in_time_zone('America/Monterrey').strftime('%d/%m/%y') %>
+  a las <%= @reservation.start_time.in_time_zone('America/Monterrey').to_formatted_s(:time) %>
+  en el laboratorio <%= @reservation.equipment.lab_space.name %>
+  ha sido cancelada.
+</p>
+<p>
+  Para cualquier aclaración, puedes comunicarte con el encargado del
+  <%= link_to 'laboratorio', [@reservation.equipment.lab_space.lab, @reservation.equipment.lab_space] %>.
+</p>
+<p>Saludos,
+<br> Makers Program</p>
+</body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   namespace :admin do
-      resources :equipment
       resources :labs
       resources :lab_spaces
+      resources :equipment
       resources :reservations
       resources :users
       resources :lab_administrations


### PR DESCRIPTION
- Show only future reservations on profile
- Show upcoming reservations count on equipment dashboard
- Disable ability to change reservation status on equipment dashboard
- Hide 'blocked' status from reservation update in admin dashboard
- Only validate date if dates changed
- Send cancellation email if status changed to cancelled
