### PR TITLE
fix creation of lab and labspaces

### DIFF
--- a/app/controllers/labs_controller.rb
+++ b/app/controllers/labs_controller.rb
@@ -86,6 +86,6 @@ class LabsController < ApplicationController
   end
 
   def lab_params
-    params.require(:lab).permit(:name, :description, :location, :image)
+    params.require(:lab).permit(:name, :description, :location, :image, :user_id)
   end
 end

--- a/app/dashboards/lab_dashboard.rb
+++ b/app/dashboards/lab_dashboard.rb
@@ -18,6 +18,7 @@ class LabDashboard < Administrate::BaseDashboard
     image: Field::Carrierwave.with_options(
       remove: true,
       ),
+    user_id: Field::Number,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -53,6 +54,7 @@ class LabDashboard < Administrate::BaseDashboard
     :description,
     :location,
     :image,
+    :user_id,
   ].freeze
 
   # Overwrite this method to customize how labs are displayed

--- a/app/dashboards/lab_space_dashboard.rb
+++ b/app/dashboards/lab_space_dashboard.rb
@@ -23,6 +23,8 @@ class LabSpaceDashboard < Administrate::BaseDashboard
     image: Field::Carrierwave.with_options(
       remove: true,
     ),
+    # user_id: Field::Number,
+    user: Field::BelongsTo.with_options(scope_name: :users)
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -36,6 +38,7 @@ class LabSpaceDashboard < Administrate::BaseDashboard
     :location,
     :hours,
     :contact_email,
+    :user,
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -52,6 +55,7 @@ class LabSpaceDashboard < Administrate::BaseDashboard
     :created_at,
     :updated_at,
     :image,
+    :user,
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -66,6 +70,7 @@ class LabSpaceDashboard < Administrate::BaseDashboard
     :contact_phone,
     :image,
     :lab,
+    :user,
   ].freeze
 
   # Overwrite this method to customize how lab spaces are displayed

--- a/app/views/admin/equipment/_form.html.erb
+++ b/app/views/admin/equipment/_form.html.erb
@@ -131,7 +131,7 @@ and renders all form fields for a resource's editable attributes.
           });
           $(this).unbind('submit').submit();
         });
-        <% if !page.resource.id.blank? # We're editing! %>
+        <% if !page.resource.id.blank? # Were editing! %>
           // Populate the existing available hours
           data = <%= raw(page.resource.available_hours.to_json) %>;
           data.forEach(function(ah, index) {

--- a/app/views/admin/equipment/_form.html.erb
+++ b/app/views/admin/equipment/_form.html.erb
@@ -131,7 +131,7 @@ and renders all form fields for a resource's editable attributes.
           });
           $(this).unbind('submit').submit();
         });
-        <% if !page.resource.id.blank? # Were editing! %>
+        <% if !page.resource.id.blank? # We're editing! %>
           // Populate the existing available hours
           data = <%= raw(page.resource.available_hours.to_json) %>;
           data.forEach(function(ah, index) {

--- a/app/views/admin/labs/_form.html.erb
+++ b/app/views/admin/labs/_form.html.erb
@@ -51,6 +51,9 @@ and renders all form fields for a resource's editable attributes.
       <div>
         <%= f.text_field :location, placeholder: "Ubicación",  :class => 'txtinput' %>
       </div>
+      <div>
+        <%= f.select :user_id, User.all.collect { |p| [p.given_name, p.id] }, include_blank: true,  :class => 'txtinput' %>
+      </div>
     </div>
   </div>
 

--- a/app/views/labs/index.html.erb
+++ b/app/views/labs/index.html.erb
@@ -5,7 +5,7 @@
     <p id="notice"><%= notice %></p>
 
     <section class="searchBar">
-      <input type="search" name="q" id="query" placeholder="Buscar..." class="txtinput">
+      <!-- <input type="search" name="q" id="query" placeholder="Buscar..." class="txtinput"> -->
     </section>
     <section class="labList">
       <% if !@labs.blank? %>


### PR DESCRIPTION
This PR does the following:

* On the admin dashboard, fixed the "New Lab" and "New Lab Space" actions, by adding fields to select the Lab admin / lab space admin when creating the lab or lab space.

* For the "New lab" I modified Administrate's Lab Dashboard by adding user_id as attributes and form attributes. This permits the params when creating a new object, and if specified so (for New lab it is not specified) it automatically renders a field on the form.

* The same is done for New Lab Space, and in this case it is specified to render a field for the lab space admin automatically, so the form does not need to be modified.