### PR TITLE
Fix outdated and incorrect labels

### DIFF
--- a/app/assets/stylesheets/_labs.scss
+++ b/app/assets/stylesheets/_labs.scss
@@ -118,7 +118,7 @@
         margin-bottom: 0;
         font-size: 1.3rem;
       }
-      .horario {
+      .labOrigin {
         color: $gray2;
         position: relative;
         font-size: .8rem;

--- a/app/assets/stylesheets/admin.css.scss
+++ b/app/assets/stylesheets/admin.css.scss
@@ -2,14 +2,14 @@
 
 @import "base";
 
-$primary: #191A45;
+$primary: #191a45;
 $fromgradient: #4e73df;
 $togradient: #224abe;
-$gray1: #8E8E9D;
-$highlight: #445BFC;
+$gray1: #8e8e9d;
+$highlight: #445bfc;
 
-$light-blue: #F2F4F8;
-$gray2: #ACACBC;
+$light-blue: #f2f4f8;
+$gray2: #acacbc;
 $text: $gray2;
 
 html {
@@ -21,10 +21,7 @@ html {
 body {
   background: transparent;
 }
-.navigation .navigation__link {
-  color: white;
-  text-decoration: none;
-}
+
 ul.inline li {
   display: inline-block;
 }
@@ -34,7 +31,7 @@ ul.inline li {
 }
 
 .main-content {
-  background-color: #F8F9FC;
+  background-color: #f8f9fc;
 }
 .navigation {
   .logo {
@@ -44,6 +41,8 @@ ul.inline li {
   }
   .navigation__link {
     opacity: .8;
+    color: white;
+    text-decoration: none;
     &.navigation__link--active {
       font-weight: 600;
       opacity: 1;
@@ -131,23 +130,23 @@ ul.inline li {
   padding: 5px 15px;
   &.white {
     background-color: #fff;
-    box-shadow: 0 2px 8px rgba(#7C86CC,.3);
+    box-shadow: 0 2px 8px rgba(#7c86cc,.3);
     color: $highlight;
     transition: box-shadow 300ms;
     &:hover {
-      box-shadow: 0 2px 15px rgba(#7C86CC, .5);
+      box-shadow: 0 2px 15px rgba(#7c86cc, .5);
     }
   }
   &.gray {
     background-color: $light-blue;
-    color: #A4A5AA;
+    color: #a4a5aa;
   }
   &.border {
     border: 1px solid $primary;
     color: $primary;
     &.with-cross::after {
       content: '×';
-      color: #A4A5C1;
+      color: #a4a5c1;
       font-weight: 800;
       margin-left: 5px;
     }

--- a/app/views/admin/equipment/show.html.erb
+++ b/app/views/admin/equipment/show.html.erb
@@ -52,7 +52,7 @@ as well as a link to its edit page.
 
             <p class="content-label">Description</p>
             <p class=""><%= page.resource.description %></p>
-            <p class="content-label">Technical description</p>
+            <p class="content-label">Technical specification</p>
             <p class=""><%= page.resource.technical_description %></p>
           </div>
         </div>

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -63,7 +63,7 @@
     </div>
     <div class="row">
       <div class="col">
-        <h2 class="mb-2">Descripci&oacute;n t&eacute;cnica</h2>
+        <h2 class="mb-2">Especificaciones t&eacute;cnicas</h2>
         <p><%= @equipment.technical_description %></p>
       </div>
     </div>

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -63,7 +63,7 @@
     </div>
     <div class="row">
       <div class="col">
-        <h2 class="mb-2">Especificaciones t&eacute;cnicas</h2>
+        <h2 class="mb-2">Especificaciones técnicas</h2>
         <p><%= @equipment.technical_description %></p>
       </div>
     </div>

--- a/app/views/home/landing.html.erb
+++ b/app/views/home/landing.html.erb
@@ -45,10 +45,10 @@
         </div>
       </div>
       <section class="queryOptionsContainer" id="default">
-        <% @capabilities.to_a.sample(5).each do |c| %>
+        <% @capabilities.to_a.each do |c| %>
           <div data-type="capabilities" class="pill white"><%= c.name %></div>
         <% end %>
-        <% @materials.to_a.sample(5).each do |m| %>
+        <% @materials.to_a.each do |m| %>
           <div data-type="materials" class="pill white"><%= m.name %></div>
         <% end %>
       </section>
@@ -104,7 +104,7 @@
             return handler();
           }
           $defaultPillBox.hide();
-          draw(window[collection].slice(0,10), collection);
+          draw(window[collection], collection);
           $pillBox.show();
         };
       };

--- a/app/views/lab_spaces/index.html.erb
+++ b/app/views/lab_spaces/index.html.erb
@@ -17,7 +17,6 @@
             tags = Array.new
             lab_space.equipment.each do | e |
               tags = tags + e.capabilities.map{|c| c.name}
-              tags = tags + e.materials.map{|m| m.name}
             end;
             tags.uniq!
           %>

--- a/app/views/lab_spaces/show.html.erb
+++ b/app/views/lab_spaces/show.html.erb
@@ -56,7 +56,7 @@
   <div class="row"></div>
 
   <section class="Equipos">
-    <h2>Equipo</h2>
+    <h2>Equipos</h2>
     <div class="EquipoGrid">
       <div class="row">
         <% @lab_space.equipment.visible.each do |e| %>
@@ -98,7 +98,7 @@
               <input type="text" name="desc" placeholder="Descripci&oacute;n" class="txtinput" id="desc">
             </div>
             <div>
-              <input type="text" name="technical-description" placeholder="Descripci&oacute;n t&eacute;cnica" class="txtinput" id="technical-description">
+              <input type="text" name="technical-description" placeholder="Especificaciones t&eacute;cnicas" class="txtinput" id="technical-description">
             </div>
             <div class="row">
               <div class="col">

--- a/app/views/lab_spaces/show.html.erb
+++ b/app/views/lab_spaces/show.html.erb
@@ -64,7 +64,7 @@
               <div class="EquipoCard" data-id="<%= e.id %>" data-lid="<%= @lab_space.lab.id %>" data-lsid="<%= @lab_space.id %>">
                 <div class="icon printer"></div>
                 <p class="name"><%= e.name %></p>
-                <p class="horario"><%= @lab_space.name %></p>
+                <p class="labOrigin"><%= @lab_space.name %></p>
               </div>
             </div>
         <% end %>
@@ -169,7 +169,7 @@
     <div class="EquipoCard" data-id="" data-lid="" data-lsid="">
       <div class="icon printer"></div>
       <p class="name"></p>
-      <p class="horario"></p>
+      <p class="labOrigin"></p>
     </div>
   </div>
 </template>

--- a/app/views/lab_spaces/show.html.erb
+++ b/app/views/lab_spaces/show.html.erb
@@ -64,7 +64,7 @@
               <div class="EquipoCard" data-id="<%= e.id %>" data-lid="<%= @lab_space.lab.id %>" data-lsid="<%= @lab_space.id %>">
                 <div class="icon printer"></div>
                 <p class="name"><%= e.name %></p>
-                <p class="horario">LuJu 12PM - 4PM</p>
+                <p class="horario"><%= @lab_space.name %></p>
               </div>
             </div>
         <% end %>
@@ -95,10 +95,10 @@
               <input type="text" name="name" placeholder="Nombre del equipo" class="txtinput large" id="name">
             </div>
             <div>
-              <input type="text" name="desc" placeholder="Descripci&oacute;n" class="txtinput" id="desc">
+              <input type="text" name="desc" placeholder="Descripción" class="txtinput" id="desc">
             </div>
             <div>
-              <input type="text" name="technical-description" placeholder="Especificaciones t&eacute;cnicas" class="txtinput" id="technical-description">
+              <input type="text" name="technical-description" placeholder="Especificaciones técnicas" class="txtinput" id="technical-description">
             </div>
             <div class="row">
               <div class="col">
@@ -169,7 +169,7 @@
     <div class="EquipoCard" data-id="" data-lid="" data-lsid="">
       <div class="icon printer"></div>
       <p class="name"></p>
-      <p class="horario">LuJu 12PM - 4PM</p>
+      <p class="horario"></p>
     </div>
   </div>
 </template>

--- a/app/views/labs/_lab_equipment_tables.html.erb
+++ b/app/views/labs/_lab_equipment_tables.html.erb
@@ -4,7 +4,7 @@
         <div class="EquipoCard" data-id="<%= e.id %>" data-lid="<%= @lab.id %>" data-lsid="<%= ls.id %>">
           <div class="icon printer"></div>
           <p class="name"><%= e.name %></p>
-          <p class="horario"><%= ls.name %></p>
+          <p class="labOrigin"><%= ls.name %></p>
         </div>
       </div>
     <% end %>

--- a/app/views/labs/_lab_equipment_tables.html.erb
+++ b/app/views/labs/_lab_equipment_tables.html.erb
@@ -1,0 +1,11 @@
+<% @lab.lab_spaces.each do |ls| %>
+    <% ls.equipment.each do |e| %>
+      <div class="col-4">
+        <div class="EquipoCard" data-id="<%= e.id %>" data-lid="<%= @lab.id %>" data-lsid="<%= ls.id %>">
+          <div class="icon printer"></div>
+          <p class="name"><%= e.name %></p>
+          <p class="horario"><%= ls.name %></p>
+        </div>
+      </div>
+    <% end %>
+<% end %>

--- a/app/views/labs/_lab_spaces_tables.html.erb
+++ b/app/views/labs/_lab_spaces_tables.html.erb
@@ -1,0 +1,12 @@
+<% @lab.lab_spaces.each do |lab_space| %>
+    <tr class="LabSpace--listitem">
+        <td><%= lab_space.name %></td>
+        <td><%= lab_space.contact_email %></td>
+        <td><%= lab_space.hours %></td>
+        <td>
+            <div class="d-flex justify-content-end">
+                <%= link_to 'Reservar', [lab_space.lab, lab_space] , class: 'reserve btn highlight' %>
+            </div>
+        </td>
+    </tr>
+<% end %>

--- a/app/views/labs/index.html.erb
+++ b/app/views/labs/index.html.erb
@@ -12,9 +12,11 @@
         <% @labs.each do |lab| %>
           <%
             tags = Array.new
-            lab.lab_spaces.each do | ls | ls.equipment.each do | e |
-              tags = tags + e.capabilities.map{|c| c.name}
-            end; end;
+            lab.lab_spaces.each do | ls | 
+              ls.equipment.each do | e |
+                tags = tags + e.capabilities.map{|c| c.name}
+              end; 
+            end;
             tags.uniq!
           %>
           <article class="labEntry">

--- a/app/views/labs/index.html.erb
+++ b/app/views/labs/index.html.erb
@@ -14,7 +14,6 @@
             tags = Array.new
             lab.lab_spaces.each do | ls | ls.equipment.each do | e |
               tags = tags + e.capabilities.map{|c| c.name}
-              tags = tags + e.materials.map{|m| m.name}
             end; end;
             tags.uniq!
           %>

--- a/app/views/labs/show.html.erb
+++ b/app/views/labs/show.html.erb
@@ -54,8 +54,8 @@
       <thead>
         <tr>
           <th>Espacio</th>
-          <th>Responsable</th>
-          <th>Horarios</th>
+          <th>Contacto</th>
+          <th>Horario</th>
           <th>Reservar</th>
         </tr>
       </thead>
@@ -63,7 +63,7 @@
         <% @lab.lab_spaces.each do |lab_space| %>
           <tr class="LabSpace--listitem">
             <td><%= lab_space.name %></td>
-            <td>Dra. Alejandra S&aacute;nchez</td>
+            <td><%= lab_space.contact_email %></td>
             <td><%= lab_space.hours %></td>
             <td>
               <div class="d-flex justify-content-end">
@@ -85,7 +85,7 @@
               <div class="EquipoCard" data-id="<%= e.id %>" data-lid="<%= @lab.id %>" data-lsid="<%= ls.id %>">
                 <div class="icon printer"></div>
                 <p class="name"><%= e.name %></p>
-                <p class="horario">LuJu 12PM - 4PM</p>
+                <p class="horario"><%= ls.name %></p>
               </div>
             </div>
           <% end %>
@@ -122,7 +122,7 @@
               <input type="text" name="desc" placeholder="Descripci&oacute;n" class="txtinput" id="desc">
             </div>
             <div>
-              <input type="text" name="technical-description" placeholder="Descripci&oacute;n t&eacute;cnica" class="txtinput" id="technical-description">
+              <input type="text" name="technical-description" placeholder="Especificaciones t&eacute;cnicas" class="txtinput" id="technical-description">
             </div>
             <div class="row">
               <div class="col">

--- a/app/views/labs/show.html.erb
+++ b/app/views/labs/show.html.erb
@@ -119,10 +119,10 @@
               <input type="text" name="name" placeholder="Nombre del equipo" class="txtinput large" id="name">
             </div>
             <div>
-              <input type="text" name="desc" placeholder="Descripci&oacute;n" class="txtinput" id="desc">
+              <input type="text" name="desc" placeholder="Descripción" class="txtinput" id="desc">
             </div>
             <div>
-              <input type="text" name="technical-description" placeholder="Especificaciones t&eacute;cnicas" class="txtinput" id="technical-description">
+              <input type="text" name="technical-description" placeholder="Especificaciones técnicas" class="txtinput" id="technical-description">
             </div>
             <div class="row">
               <div class="col">
@@ -193,7 +193,7 @@
     <div class="EquipoCard" data-id="" data-lid="" data-lsid="">
       <div class="icon printer"></div>
       <p class="name"></p>
-      <p class="horario">LuJu 12PM - 4PM</p>
+      <p class="horario"></p>
     </div>
   </div>
 </template>

--- a/app/views/labs/show.html.erb
+++ b/app/views/labs/show.html.erb
@@ -171,7 +171,7 @@
     <div class="EquipoCard" data-id="" data-lid="" data-lsid="">
       <div class="icon printer"></div>
       <p class="name"></p>
-      <p class="horario"></p>
+      <p class="labOrigin"></p>
     </div>
   </div>
 </template>

--- a/app/views/labs/show.html.erb
+++ b/app/views/labs/show.html.erb
@@ -60,18 +60,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @lab.lab_spaces.each do |lab_space| %>
-          <tr class="LabSpace--listitem">
-            <td><%= lab_space.name %></td>
-            <td><%= lab_space.contact_email %></td>
-            <td><%= lab_space.hours %></td>
-            <td>
-              <div class="d-flex justify-content-end">
-                <%= link_to 'Reservar', [lab_space.lab, lab_space] , class: 'reserve btn highlight' %>
-              </div>
-            </td>
-          </tr>
-        <% end %>
+        <%= render "lab_spaces_tables" %>
       </tbody>
     </table>
   </section>
@@ -79,18 +68,7 @@
     <h2>Equipos</h2>
     <div class="EquipoGrid">
       <div class="row">
-        <% @lab.lab_spaces.each do |ls| %>
-          <% ls.equipment.each do |e| %>
-            <div class="col-4">
-              <div class="EquipoCard" data-id="<%= e.id %>" data-lid="<%= @lab.id %>" data-lsid="<%= ls.id %>">
-                <div class="icon printer"></div>
-                <p class="name"><%= e.name %></p>
-                <p class="horario"><%= ls.name %></p>
-              </div>
-            </div>
-          <% end %>
-        <% end %>
-
+      <%= render "lab_equipment_tables" %>
         <%# TODO: should be: if policy(@lab_space.equipment.new).create? %>
         <% if policy(:equipment).new? %>
         <div class="col-4">

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -34,7 +34,7 @@
       <% end %>
       <li><%= link_to "Laboratorios", labs_path, class: 'dropdown-item' %></li>
       <li><%= link_to "Espacios", lab_spaces_path, class: 'dropdown-item' %></li>
-      <li><%= link_to "Equipo", equipment_index_path, class: 'dropdown-item' %></li>
+      <li><%= link_to "Equipos", equipment_index_path, class: 'dropdown-item' %></li>
     </ul>
   </nav>
 </div>


### PR DESCRIPTION
#116 
This PR:
+ Changes the labels that were written in singular

+ Changes the labels from "Technical Description" to "Technical Specifications"

+ Removes the materials from the tag list in the lab view

+ Changes the fixed name to an email from the person in charge of the space

+ Changes the fixed schedule to the name of the space to which each team belongs

+ Eliminates the restriction that shows only the first 10 materials and capacities