### PR TITLE
Remove references to Admin role in privilege policies

### DIFF
--- a/app/dashboards/lab_administration_dashboard.rb
+++ b/app/dashboards/lab_administration_dashboard.rb
@@ -8,7 +8,7 @@ class LabAdministrationDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    admin: Field::BelongsTo.with_options(class_name: "User", scope: -> { User.admin.or(User.lab_admin) }),
+    admin: Field::BelongsTo.with_options(class_name: "User", scope: -> { User.superadmin.or(User.lab_admin) }),
     space: PolymorphicWithUserField.with_options(classes: [Lab, LabSpace], scope_names: { Lab: :managed_labs, LabSpace: :managed_lab_spaces }),
     id: Field::Number,
     admin_id: Field::Number,

--- a/app/policies/available_hour_policy.rb
+++ b/app/policies/available_hour_policy.rb
@@ -9,7 +9,7 @@ class AvailableHourPolicy < ApplicationPolicy
 
   def default_authorization
     return false unless user
-    return user.manages?(record.equipment) if user.admin? || user.lab_admin?
+    return user.manages?(record.equipment) if user.superadmin? || user.lab_admin?
 
     user.superadmin?
   end

--- a/app/policies/capability_policy.rb
+++ b/app/policies/capability_policy.rb
@@ -18,6 +18,6 @@ class CapabilityPolicy < ApplicationPolicy
   def default_authorization
     return false unless user
 
-    user.superadmin? || user.admin? || user.lab_admin?
+    user.superadmin? || user.lab_admin?
   end
 end

--- a/app/policies/lab_administration_policy.rb
+++ b/app/policies/lab_administration_policy.rb
@@ -2,7 +2,7 @@ class LabAdministrationPolicy < ApplicationPolicy
   def new?
     return false unless user
 
-    user.superadmin? || user.admin?
+    user.superadmin?
   end
 
   def update?
@@ -11,7 +11,7 @@ class LabAdministrationPolicy < ApplicationPolicy
 
   def default_authorization
     return false unless user
-    return user.manages?(record.space) if user.admin?
+    return user.manages?(record.space) if user.superadmin?
 
     user.superadmin?
   end

--- a/app/policies/material_policy.rb
+++ b/app/policies/material_policy.rb
@@ -18,6 +18,6 @@ class MaterialPolicy < ApplicationPolicy
   def default_authorization
     return false unless user
 
-    user.superadmin? || user.admin? || user.lab_admin?
+    user.superadmin? || user.lab_admin?
   end
 end

--- a/app/policies/role_policy.rb
+++ b/app/policies/role_policy.rb
@@ -11,7 +11,7 @@ class RolePolicy
       roles = User.roles.keys.map { |role| [role.titleize, role] }
       return roles if user.superadmin?
 
-      roles - [%w[Superadmin superadmin]] if user.admin?
+      roles - [%w[Superadmin superadmin]] if user.superadmin?
     end
 
     def resolve_admin

--- a/app/policies/tag_associations_policy.rb
+++ b/app/policies/tag_associations_policy.rb
@@ -10,7 +10,7 @@ class TagAssociationsPolicy < ApplicationPolicy
   def new?
     return false unless user
 
-    user.superadmin? || user.admin? || user.lab_admin?
+    user.superadmin? || user.lab_admin?
   end
 
   def update?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -2,13 +2,13 @@ class UserPolicy < ApplicationPolicy
   def index?
     return false unless user
 
-    user.superadmin? || user.admin? || user.lab_admin?
+    user.superadmin? || user.lab_admin?
   end
 
   def show?
     return false unless user
 
-    user.id == record.id || user.superadmin? || user.admin? || user.lab_admin?
+    user.id == record.id || user.superadmin? || user.lab_admin?
   end
 
   def create?
@@ -18,7 +18,7 @@ class UserPolicy < ApplicationPolicy
   def update?
     return false unless user
 
-    user.id == record.id || user.superadmin? || user.admin?
+    user.id == record.id || user.superadmin
   end
 
   def destroy?


### PR DESCRIPTION
This PR:

+ Removes any reference to the "admin" method called on user objects in several privilege policies given that "admin" was recently replaced by "superadmin" and the references are crashing the app in multiple interactions.