### PR TITLE
Fix click on pills returned to the available options

### DIFF
--- a/app/views/home/landing.html.erb
+++ b/app/views/home/landing.html.erb
@@ -79,7 +79,6 @@
           return `<div data-id="${r.id}" data-type="${type}" class="pill white">${r.name}</div>`;
         });
         $pillBox.html(resultDivs);
-        bindPills();
       }
       const processQueryOnCollection = function(collection) {
         return function() {
@@ -116,10 +115,7 @@
       $queryCap.on('input', filterCapabilities);
       $queryMat.on('input', filterMaterials);
 
-      function bindPills() {
-        $('.queryOptionsContainer .pill.white').click(onOptionClick);
-      }
-      bindPills();
+      $('.queryOptionsContainer').on('click', '.pill.white', onOptionClick);
 
       function onOptionClick() {
         console.log('onpillclick');
@@ -165,4 +161,3 @@
     <% flash.discard %>
   </body>
 </html>
-


### PR DESCRIPTION
This PR addresses issue #124 :

- After selecting a pill in the capacity/material options and then removing it, it wasn't possible to select it again.
- This was because `.click(...)` was being used; it doesn't work on dynamically created elements.
- Instead of that, `.on('click', ...)` is now used.