### PR TITLE
Fix host for mailer

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,5 +100,5 @@ Rails.application.configure do
     :authentication => :plain,
     :enable_starttls_auto => true
   }
-  config.action_mailer.default_url_options = { host: 'makers-program-staging.herokuapp.com' }
+  config.action_mailer.default_url_options = { host: 'makersprogram.herokuapp.com' }
 end


### PR DESCRIPTION
This PR addresses issue #:

- The host used for the mailer has been replaced after the old Heroku account was lost and the app was deployed again.