### PR TITLE
Add User Attribute to Lab Spaces dashboard

### DIFF
--- a/app/dashboards/lab_space_dashboard.rb
+++ b/app/dashboards/lab_space_dashboard.rb
@@ -16,6 +16,7 @@ class LabSpaceDashboard < Administrate::BaseDashboard
     description: Field::Text,
     hours: Field::String,
     location: Field::String,
+    user: Field::BelongsTo,
     contact_email: Field::String,
     contact_phone: Field::String,
     created_at: Field::DateTime,


### PR DESCRIPTION
### What does this PR do?

* Fixes a bug in the Lab Spaces dashboard that crashed the app because the 'User' attribute was not listed in the Attribute Types hash in the lab spaces dashboard file.

#### Merge Checklist:

- [x] The branch is up-to-date (i.e. rebased) with the base branch
- [x] Is GPA high enough?