### PR TITLE
Fix Equipment Reservations Calendar in Admin Dashboard

### DIFF
--- a/app/controllers/admin/equipment_controller.rb
+++ b/app/controllers/admin/equipment_controller.rb
@@ -22,6 +22,11 @@ module Admin
       redirect_to admin_equipment_index_path
     end
 
+    def show
+      @equipment = Equipment.find(params[:id])
+      super
+    end
+
     # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
     # for more information
 

--- a/app/dashboards/lab_space_dashboard.rb
+++ b/app/dashboards/lab_space_dashboard.rb
@@ -16,6 +16,7 @@ class LabSpaceDashboard < Administrate::BaseDashboard
     description: Field::Text,
     hours: Field::String,
     location: Field::String,
+    user: Field::BelongsTo,
     contact_email: Field::String,
     contact_phone: Field::String,
     created_at: Field::DateTime,

--- a/app/views/admin/equipment/show.html.erb
+++ b/app/views/admin/equipment/show.html.erb
@@ -52,7 +52,7 @@ as well as a link to its edit page.
 
             <p class="content-label">Description</p>
             <p class=""><%= page.resource.description %></p>
-            <p class="content-label">Technical specification</p>
+            <p class="content-label">Technical Specification</p>
             <p class=""><%= page.resource.technical_description %></p>
           </div>
         </div>
@@ -62,12 +62,12 @@ as well as a link to its edit page.
           <div class="col">
             <div class="card ComingUp">
               <div class="card-body">
-                <h4 class="card-title">Upcoming reservations</h4>
+                <h4 class="card-title">Upcoming Reservations</h4>
                 <table class="ReservationTable">
                   <tbody>
                     <% res = page.resource.reservations.confirmed.upcoming(5) %>
                     <% if res.length == 0 %>
-                      <p>No upcoming reservations</p>
+                      <p>No upcoming reservations.</p>
                     <% else %>
                       <% res.each do | r |  %>
                         <tr onclick="window.location='<%= admin_reservation_path(r) %>';">
@@ -127,6 +127,7 @@ as well as a link to its edit page.
 
 <%
   # TODO: refactor this
+  available_hours = @equipment.available_hours
   reservations = []
   page.resource.reservations.each do | r |
     reservations.push({
@@ -151,6 +152,28 @@ as well as a link to its edit page.
   <script>
     let calendar;
     const reservations = <%= raw(reservations.to_json) %>;
+    const available_hours = <%= raw(available_hours.to_json) %>;
+   
+    // Map business (available) hours
+
+    const dateMap = {
+        "sunday": 0,
+        "monday": 1,
+        "tuesday": 2,
+        "wednesday": 3,
+        "thursday": 4,
+        "friday": 5,
+        "saturday": 6,
+      };
+    
+    let bhours = available_hours.map(ah => {
+        return {
+          daysOfWeek: [dateMap[ah.day_of_week]],
+          startTime: new Date(ah.start_time).toTimeString().substr(0, 5),
+          endTime: new Date(ah.end_time).toTimeString().substr(0, 5),
+        };
+      });
+
     document.addEventListener('DOMContentLoaded', function() {
       var calendarEl = document.getElementById('calendar');
 
@@ -176,13 +199,7 @@ as well as a link to its edit page.
       eventBackgroundColor: 'rgba(68, 93, 252, .77)',
       minTime: "06:00:00",
       maxTime: "22:00:00",
-      businessHours: {
-        // days of week. an array of zero-based day of week integers (0=Sunday)
-        daysOfWeek: [ 1, 2, 3, 4,5 ], // Monday - Thursday
-
-        startTime: '08:00', // a start time (10am in this example)
-        endTime: '18:00', // an end time (6pm in this example)
-      }
+      businessHours: bhours
       });
 
       calendar.render();

--- a/app/views/admin/equipment/show.html.erb
+++ b/app/views/admin/equipment/show.html.erb
@@ -129,7 +129,9 @@ as well as a link to its edit page.
   # TODO: refactor this
   available_hours = @equipment.available_hours
   reservations = []
-  page.resource.reservations.each do | r |
+  res = @equipment.reservations
+  res = res.confirmed.or(res.blocked)
+  res.each do | r |
     reservations.push({
       "id" => r.id,
       "start" => r.start_time,

--- a/app/views/equipment/show.html.erb
+++ b/app/views/equipment/show.html.erb
@@ -3,15 +3,15 @@
   available_hours = @equipment.available_hours
 
   reservations = []
-  rev = @equipment.reservations
-  rev = rev.confirmed.or(rev.blocked)
-  rev.each do | eq |
+  res = @equipment.reservations
+  res = res.confirmed.or(res.blocked)
+  res.each do | r |
     reservations.push({
-      "id" => eq.id,
-      "start" => eq.start_time,
-      "end" => eq.end_time,
-      "title" => (user_signed_in? and current_user.id == eq.user_id) ? "#{current_user.given_name} #{current_user.last_name}" : "Reservación",
-      "isUser" => (user_signed_in? and current_user.id == eq.user_id)
+      "id" => r.id,
+      "start" => r.start_time,
+      "end" => r.end_time,
+      "title" => (user_signed_in? and current_user.id == r.user_id) ? "#{current_user.given_name} #{current_user.last_name}" : "Reservación",
+      "isUser" => (user_signed_in? and current_user.id == r.user_id)
     })
   end
 %>


### PR DESCRIPTION
### What does this PR do?

* Implements a feature that blocks (grays out) the calendar space that does not correspond to the specific equipment's registered available hours (not including reserved slots).
* Closes #105 

#### Merge Checklist:

- [x] The branch is up-to-date (i.e. rebased) with the base branch
- [x] Is GPA high enough?