### PR TITLE
D001 hidden button bug fix

### DIFF
--- a/app/controllers/admin/equipment_controller.rb
+++ b/app/controllers/admin/equipment_controller.rb
@@ -18,7 +18,7 @@ module Admin
     def destroy
       @equipment = Equipment.find(params[:id])
       @equipment.update_attribute(:hidden, !@equipment.hidden)
-      flash[:notice] = "Equipment was successfully #{@equipment.hidden ? 'hidden' : 'unhidden'}."
+      flash[:notice] = "Equipment was successfully #{@equipment.hidden ? 'hidden ' : 'unhidden'}."
       redirect_to admin_equipment_index_path
     end
 

--- a/app/views/admin/equipment/_collection.html.erb
+++ b/app/views/admin/equipment/_collection.html.erb
@@ -86,7 +86,7 @@ to display a collection of resources in an HTML table.
             [namespace, resource],
             class: "text-color-red",
             method: :delete,
-            data: { confirm: t("administrate.actions.confirm") }
+
           ) if show_action? :destroy, resource %></td>
         <% end %>
       </tr>


### PR DESCRIPTION
The alert which was being displayed on the prompt when attempting to hide/unhide equipment was removed and now the equipment just hides/unhides without further confirmation