### PR TITLE
TT012 Send Email on Status Change

### DIFF
--- a/app/mailers/makers_mailer.rb
+++ b/app/mailers/makers_mailer.rb
@@ -1,8 +1,8 @@
 class MakersMailer < ApplicationMailer
   default from: 'Plataforma Makers <Makers.iag@servicios.tec.mx>'
 
-  def cancellation_email(reservation)
+  def status_email(reservation)
     @reservation = reservation
-    mail(to: @reservation.user.email, subject: 'Tu reservación ha sido rechazada.', 'X-Priority': '1')
+    mail(to: @reservation.user.email, subject: 'Tu reservación ha sido ' + I18n.t("activerecord.models.reservations.attributes.status.#{@reservation.status}", locale: :es), 'X-Priority': '1')
   end
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -12,7 +12,7 @@ class Reservation < ApplicationRecord
   scope :upcoming, ->(limit) { where('start_time > ?', Time.current).order(:start_time).limit(limit) }
   scope :future, -> { where('start_time > ?', Time.current).order(:start_time) }
 
-  after_save :check_cancellation, if: -> { previous_changes.include?(:status) }
+  after_save :check_status, if: -> { previous_changes.include?(:status) }
 
   def available_at(st, et, day)
     slots = equipment.available_hours
@@ -96,7 +96,7 @@ class Reservation < ApplicationRecord
     time_a.strftime("%H%M") == time_b.strftime("%H%M")
   end
 
-  def check_cancellation
-    MakersMailer.cancellation_email(self).deliver_now if rejected?
+  def check_status
+    MakersMailer.status_email(self).deliver_now if not blocked?
   end
 end

--- a/app/views/makers_mailer/status_email.html.erb
+++ b/app/views/makers_mailer/status_email.html.erb
@@ -10,7 +10,7 @@
   para el día <%= @reservation.start_time.in_time_zone('America/Monterrey').strftime('%d/%m/%y') %>
   a las <%= @reservation.start_time.in_time_zone('America/Monterrey').to_formatted_s(:time) %>
   en el laboratorio <%= @reservation.equipment.lab_space.name %>
-  ha sido rechazada.
+  ha sido <%= I18n.t("activerecord.models.reservations.attributes.status.#{@reservation.status}", locale: :es) %>.
 </p>
 <p>
   Para cualquier aclaración, puedes comunicarte con el encargado del

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,16 @@ en:
               past: 'Cannot reserve a space in the past.'
               start_time: 'End time cannot be before start time.'
               overlapping: 'Reservation overlaps with another one.'
+    models:
+      reservations:
+        attributes:
+          status:
+            one: 'Status'
+            confirmed: 'Confirmed'
+            rejected: 'Rejected'
+            pending: 'Pending'
+            cancelled: 'Cancelled'
+            complete: 'Completed'
   administrate:
     actions:
       show_resource: "%{name}"
@@ -75,7 +85,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -101,7 +111,7 @@ en:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - January
     - February
     - March

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -90,5 +90,13 @@ es:
               past: 'La reservación no puede estar en el pasado.'
               start_time: 'La hora de terminación no puede ser antes que la hora de inicio.'
               overlapping: 'La reservación traslapa con otra reservación.'
-
-
+    models:
+      reservations:
+        attributes:
+          status:
+            one: 'Status'
+            confirmed: 'Confirmada'
+            rejected: 'Rechazada'
+            pending: 'puesta en Pendiente'
+            cancelled: 'Cancelada'
+            complete: 'Completada'


### PR DESCRIPTION
The mailer service has been changed to send a notification email whenever the status changed instead of only when it was rejected