### PR TITLE
Removed completed status

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,5 +1,5 @@
 class Reservation < ApplicationRecord
-  enum status: [:confirmed, :pending, :rejected, :complete, :cancelled, :blocked]
+  enum status: [:confirmed, :pending, :rejected, :cancelled, :blocked]
   enum purpose: [:academic, :entrepreneurship, :research, :personal]
 
   belongs_to :equipment

--- a/app/views/admin/equipment/show.html.erb
+++ b/app/views/admin/equipment/show.html.erb
@@ -167,11 +167,11 @@ as well as a link to its edit page.
             </div>
             <%= javascript_include_tag 'application' %>
             <div id="WeeklyUsage">
-              <%= line_chart [{name:"Total", data:page.resource.reservations.complete.group_by_day_of_week(:start_time, format: "%a").count},
-                              {name:"Academic", data:page.resource.reservations.complete.academic.group_by_day_of_week(:start_time, format: "%a").count},
-                              {name:"Entrepreneurship", data:page.resource.reservations.complete.entrepreneurship.group_by_day_of_week(:start_time, format: "%a").count},
-                              {name:"Research", data:page.resource.reservations.complete.research.group_by_day_of_week(:start_time, format: "%a").count},
-                              {name:"Personal", data:page.resource.reservations.complete.personal.group_by_day_of_week(:start_time, format: "%a").count}] %>
+              <%= line_chart [{name:"Total", data:page.resource.reservations.confirmed.group_by_day_of_week(:start_time, format: "%a").count},
+                              {name:"Academic", data:page.resource.reservations.confirmed.academic.group_by_day_of_week(:start_time, format: "%a").count},
+                              {name:"Entrepreneurship", data:page.resource.reservations.confirmed.entrepreneurship.group_by_day_of_week(:start_time, format: "%a").count},
+                              {name:"Research", data:page.resource.reservations.confirmed.research.group_by_day_of_week(:start_time, format: "%a").count},
+                              {name:"Personal", data:page.resource.reservations.confirmed.personal.group_by_day_of_week(:start_time, format: "%a").count}] %>
             </div>
             <div class="row">
               <div class="col">
@@ -180,8 +180,8 @@ as well as a link to its edit page.
             </div>
             <div id="HourlyUsageDetail">
               <%# Group the reservations by the week day they correspond to and then create graph using the resulting hash %>
-              <% weeklyStats = page.resource.reservations.complete.group_by{ | res | res.start_time.wday } %>
-              <% completeStats = {'7': page.resource.reservations.complete}.merge(weeklyStats) %>
+              <% weeklyStats = page.resource.reservations.confirmed.group_by{ | res | res.start_time.wday } %>
+              <% completeStats = {'7': page.resource.reservations.confirmed}.merge(weeklyStats) %>
               <%# Array used to display the name of the data in the graph %>
               <% weekDays = ['Sunday', 'Monday', 'Tuseday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Total'] %>
               <%= area_chart completeStats.map { | day |

--- a/app/views/shared/_calendar.js.erb
+++ b/app/views/shared/_calendar.js.erb
@@ -64,26 +64,14 @@ function populateStatusField(status) {
     case "pending":
       icon.html('<%= j inline_svg_tag "warning.svg", class: 'text-warning', size: '1.3em' %>');
       field.html('Pendiente');
-      if (!currentUserAdmin) {
-        field.attr('data-content', 'La reservación debe ser aprobada por un administrador.');
-        field.popover('enable');
-      } else {
-        field.popover('disable');
-      }
-      break;
-    case "rejected":
-      icon.html('<%= j inline_svg_tag "rejected.svg", class: 'text-danger', size: '1.3em' %>');
-      field.html('Rechazada');
-      field.attr('data-content', 'Reservación rechazada por administrador.');
+      field.attr('data-content', 'La reservación debe ser aprobada por un administrador.');
       field.popover('enable');
       break;
-    case "complete":
-      icon.html('<%= j inline_svg_tag "checkmark-filled.svg", class: 'text-success', size: '1.3em' %>');
-      field.html('Completada');
-      field.popover('disable');
+    case "rejected":
+      // Never displayed by calendar, nor does it block other reservations
       break;
     case "cancelled":
-      // Cancelled functions are filtered, so do nothing here
+      // Cancelled functions are also filtered, so do nothing here
       break;
     case "blocked":
       icon.html('<%= j inline_svg_tag "octagon-warning.svg", class: 'text-danger', size: '1.3em' %>');

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,7 +80,6 @@ en:
             rejected: 'Rejected'
             pending: 'Pending'
             cancelled: 'Cancelled'
-            complete: 'Completed'
   administrate:
     actions:
       show_resource: "%{name}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -109,4 +109,3 @@ es:
             rejected: 'Rechazada'
             pending: 'puesta en Pendiente'
             cancelled: 'Cancelada'
-            complete: 'Completada'

--- a/db/migrate/20201028175102_remove_completed_status_from_reservation.rb
+++ b/db/migrate/20201028175102_remove_completed_status_from_reservation.rb
@@ -1,0 +1,9 @@
+class RemoveCompletedStatusFromReservation < ActiveRecord::Migration[5.2]
+  def change
+    # Remove all records with value "3" (i.e. completed)
+    execute "DELETE FROM reservations WHERE status = 3;"
+    # Since completed enum value is 3, move all values above it down by one
+    execute "UPDATE reservations SET status = 3 WHERE status = 4;" # cancelled
+    execute "UPDATE reservations SET status = 4 WHERE status = 5;" # blocked
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_15_211607) do
+ActiveRecord::Schema.define(version: 2020_10_28_175102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Status was never used in system, therefore no reason to change from "confirmed" to "completed".

* Added migration to change the status enum on reservations
* Made use-graphs look for confirmed reservations