### PR TITLE
Updated Reservation Rules

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -128,13 +128,10 @@ class Reservation < ApplicationRecord
   def rest_time_reservation
     # Creates a blocked reservation in case max usage has been reached
     duration = (self.status == "confirmed"? ((self.end_time - self.start_time) / 3600) : 0.0)
-    puts "YO WHaduppp niGAAA"
-    puts (self.status == "confirmed")
     used_time = max_usage_time(self.start_time, self.equipment.max_usage)
-    puts((duration + used_time) >= self.equipment.max_usage.to_f)
     if((duration + used_time) >= self.equipment.max_usage.to_f)
       end_rest = (self.end_time + self.equipment.rest_time.hours).to_datetime
-      new_reservation = Reservation.new(status: "blocked", purpose: 0, comment: "Bloquear reservas del equipo para evitar perdida en rendimiento",
+      new_reservation = Reservation.new(status: "blocked", comment: "Bloquear reservas del equipo para evitar perdida en rendimiento",
                                         start_time: self.end_time, end_time: end_rest, equipment_id: self.equipment.id,
                                         updated_at: Time.now, user_id: self.equipment.lab_space.user.id)
       new_reservation.save


### PR DESCRIPTION
Updated rules to only look at confirmed reservations to avoid blocking space on pending reservations, also to delete pending reservations when you make a blocked reservation that overlaps