### PR TITLE
Added Reservation dragging & resizing

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'Plataforma Makers <' + ENV['TEC_USERNAME'] + '>'
+  default from: "Plataforma Makers <#{ENV['TEC_USERNAME']}>"
   layout 'mailer'
 end

--- a/app/mailers/makers_mailer.rb
+++ b/app/mailers/makers_mailer.rb
@@ -1,5 +1,5 @@
 class MakersMailer < ApplicationMailer
-  default from: 'Plataforma Makers <' + ENV['TEC_USERNAME'] + '>'
+  default from: "Plataforma Makers <#{ENV['TEC_USERNAME']}>"
 
   def status_email(reservation)
     @reservation = reservation

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -120,9 +120,7 @@ class Reservation < ApplicationRecord
     used_time = max_usage_time(self.start_time, self.equipment.max_usage)
     if ((duration + used_time) > self.equipment.max_usage.to_f)
       errors.add(:end_time, I18n.t('activerecord.errors.models.reservation.attributes.date.max_usage'))
-      false
     end
-    true
   end
 
   def rest_time_reservation

--- a/app/views/shared/_calendar.js.erb
+++ b/app/views/shared/_calendar.js.erb
@@ -19,11 +19,12 @@ function removeStatusFromTitle(title) {
   return title.indexOf("(") == -1 ? title : title.substr(0, title.indexOf("(") - 1);
 }
 
-function ajaxCall(method, url, cb) {
+function ajaxCall(method, url, cb, payload = {}) {
+  payload['authenticity_token'] = window._token;
   $.ajax({
     url: url,
     method: method,
-    data: { authenticity_token: window._token },
+    data: payload,
     dataType: 'json',
     success: (data) => { cb(data); },
     error: function(xhr, status, err) {
@@ -31,6 +32,16 @@ function ajaxCall(method, url, cb) {
       alert('Se ha producido un error. Por favor, intenta más tarde.');
     }
   });
+}
+
+function updateEventAjax(info) {
+  let payload = {
+    reservation: {
+      start_time: info.event.start.toISOString(),
+      end_time: info.event.end.toISOString()
+    }
+  };
+  ajaxCall('PATCH', `/equipment/${eqid}/reservations/${info.event.id}.json`, () => {}, payload);
 }
 
 function buildEvent(event) {
@@ -133,7 +144,6 @@ $(document).ready(() => {
 
 <% if user_signed_in? %>
   const signedInOptions = {
-    selectable: true,
     selectConstraint: "businessHours",
     selectOverlap: currentUserAdmin,
     select: (selInfo) => {
@@ -146,11 +156,19 @@ $(document).ready(() => {
       };
       $('#tmpEventStartDisplay').html(buildDateString(selInfo.start))
       $('#tmpEventEndDisplay').html(buildDateString(selInfo.end))
+    },
+    editable: currentUserAdmin,
+    eventResizableFromStart: true,
+    eventOverlap: false,
+    eventConstraint: "businessHours",
+    eventDrop: updateEventAjax,
+    eventResize: updateEventAjax,
+    validRange: currentUserAdmin ? {} : function(nowDate) {
+      return { start: nowDate };
     }
   };
 <% else %>
   const visitor_options = {
-    selectable: true,
     select: (selInfo) => {
       alert('Tienes que iniciar sesión para reservar.');
     },
@@ -167,6 +185,7 @@ document.addEventListener('DOMContentLoaded', () => {
     nowIndicator: true,
     eventTextColor: 'white',
     eventBackgroundColor: 'rgba(68, 93, 252, .77)',
+    selectable: true,
     slotMinTime: "06:00:00",
     slotMaxTime: "22:00:00",
     businessHours: bhours,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'Plataforma Makers <' + ENV['TEC_USERNAME'] + '>'
+  config.mailer_sender = "Plataforma Makers <#{ENV['TEC_USERNAME']}>"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe Reservation, type: :model do
     )
 
     res = build(:reservation,
-                start_time: future_monday.at_noon,
-                end_time: future_monday.at_noon + 8.hour, # Ends at 20:00
+                start_time: future_monday.at_noon + 5.hours, # 17:00
+                end_time: future_monday.at_noon + 6.hours, # 18:00
                 equipment: equipment,
                 user: user
     )
@@ -83,8 +83,8 @@ RSpec.describe Reservation, type: :model do
     )
 
     res = build(:reservation,
-                start_time: future_monday.at_noon + 10.hour, # 22:00
-                end_time: future_monday.at_end_of_day + 4.hour, # Tuesday, 3:59
+                start_time: future_monday.at_end_of_day - 1.hour, # Monday, 22:59
+                end_time: future_monday.at_end_of_day + 1.hour, # Tuesday, 0:59
                 equipment: equipment,
                 user: user)
 


### PR DESCRIPTION
Admins can now now be drag events to other slots & resize their duration (within constraints)

* Added a constraint so user can no longer see past reservations on calendar
* Fixed bug on mailer specification